### PR TITLE
 [WIP] Add standalone kernels repository (after rebase)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,13 @@ uuid = "1e25b1b3-a3a0-53b8-8729-934c9d7c4cc0"
 version = "0.0.1"
 
 [deps]
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
 PyCall = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,13 @@ version = "0.0.1"
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 PyCall = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"

--- a/src/GPnet.jl
+++ b/src/GPnet.jl
@@ -1,6 +1,6 @@
 module GPnet
 
-using PyCall
+using PyCall, Distances
 
 export
     gpflow,
@@ -19,6 +19,19 @@ function minimize!(opt, m) end
 function predict_f(m, Xnew) end
 function predict_f_samples(m, Xnew, num_samples) end
 
+function elementwise end
+
+const pw = pairwise
+const ew = elementwise
+
+# Load necessary utilities
+include(joinpath("utils", "abstract_data_set.jl"))
+
+
+include("kernels.jl")
+
+# Load the GPFlow Interface
 include("gpflow.jl")
+
 
 end # module

--- a/src/GPnet.jl
+++ b/src/GPnet.jl
@@ -1,6 +1,8 @@
 module GPnet
 
-using PyCall, Distances
+using PyCall, Distances, Random
+import Base.Broadcast: broadcast_shape
+using LinearAlgebra
 
 export
     gpflow,
@@ -24,8 +26,14 @@ function elementwise end
 const pw = pairwise
 const ew = elementwise
 
+const AV{T} = AbstractVector{T}
+const AM{T} = AbstractMatrix{T}
+const AVM{T} = AbstractVecOrMat{T}
+
 # Load necessary utilities
+include(joinpath("utils", "zygote_rules.jl"))
 include(joinpath("utils", "abstract_data_set.jl"))
+include(joinpath("utils", "distances.jl"))
 
 
 include("kernels.jl")

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -1,37 +1,556 @@
-abstract type Kernel end
-
+"""
+This code is partially taken from Stheno.jl
+https://www.github..com/willtebbutt/Stheno.jl
+"""
 
 import Base: +, *, zero, cos
 using Distances: sqeuclidean, SqEuclidean, Euclidean
 using Base.Broadcast: broadcast_shape
 using LinearAlgebra: isposdef, checksquare
+using Zygote: @adjoint
 
 const AV{T} = AbstractVector{T}
 const AM{T} = AbstractMatrix{T}
 const AVM{T} = AbstractVecOrMat{T}
 
-export
-    Kernel,
-    ZeroKernel,
-    zero
 abstract type Kernel end
 
-
+#
+# Base Kernels
+#
 
 """
     ZeroKernel <: Kernel
+
 A rank 0 `Kernel` that always returns zero.
 """
 struct ZeroKernel{T<:Real} <: Kernel end
 ZeroKernel() = ZeroKernel{Float64}()
 zero(::Kernel) = ZeroKernel()
 
-function (k::ZeroKernel{T})(x::AV, x′::AV; type=:pairwise) where {T}
-    if type == :elementwise
-        return zeros(T, broadcast_shape(size(x), size(x′)))
-    elseif type == :pairwise
-        return zeros(T, length(x), length(x′))
-    else
-        @error "`$type` is not a valid kernel application type" 
+# Binary methods.
+ew(k::ZeroKernel{T}, x::AV, x′::AV) where {T} = zeros(T, broadcast_shape(size(x), size(x′)))
+pw(k::ZeroKernel{T}, x::AV, x′::AV) where {T} = zeros(T, length(x), length(x′))
+
+# Unary methods.
+ew(k::ZeroKernel{T}, x::AV) where {T} = zeros(T, length(x))
+pw(k::ZeroKernel{T}, x::AV) where {T} = zeros(T, length(x), length(x))
+
+
+
+"""
+    OneKernel{T<:Real} <: Kernel
+
+A rank 1 constant `Kernel`. Useful for consistency when creating composite Kernels,
+but (almost certainly) shouldn't be used as a base `Kernel`.
+"""
+struct OneKernel{T<:Real} <: Kernel end
+OneKernel() = OneKernel{Float64}()
+
+# Binary methods.
+ew(k::OneKernel{T}, x::AV, x′::AV) where {T} = ones(T, broadcast_shape(size(x), size(x′)))
+pw(k::OneKernel{T}, x::AV, x′::AV) where {T} = ones(T, length(x), length(x′))
+
+# Unary methods.
+ew(k::OneKernel{T}, x::AV) where {T} = ones(T, length(x))
+pw(k::OneKernel{T}, x::AV) where {T} = ones(T, length(x), length(x))
+
+
+
+"""
+    ConstKernel{T} <: Kernel
+
+A rank 1 kernel that returns the same value `c` everywhere.
+"""
+struct ConstKernel{T} <: Kernel
+    c::T
+end
+
+# Binary methods.
+ew(k::ConstKernel, x::AV, x′::AV) = fill(k.c, broadcast_shape(size(x), size(x′))...)
+pw(k::ConstKernel, x::AV, x′::AV) = fill(k.c, length(x), length(x′))
+
+# Unary methods.
+ew(k::ConstKernel, x::AV) = fill(k.c, length(x))
+pw(k::ConstKernel, x::AV) = pw(k, x, x)
+
+
+
+"""
+    EQ <: Kernel
+
+The standardised Exponentiated Quadratic kernel (no free parameters).
+"""
+struct EQ <: Kernel end
+
+# Binary methods.
+ew(::EQ, x::AV, x′::AV) = exp.(.-ew(SqEuclidean(), x, x′) ./ 2)
+pw(::EQ, x::AV, x′::AV) = exp.(.-pw(SqEuclidean(), x, x′) ./ 2)
+
+# Unary methods.
+ew(::EQ, x::AV) = exp.(.-ew(SqEuclidean(), x) ./ 2)
+pw(::EQ, x::AV) = exp.(.-pw(SqEuclidean(), x) ./ 2)
+
+
+
+"""
+    PerEQ
+
+The usual periodic kernel derived by mapping the input domain onto the unit circle.
+"""
+struct PerEQ <: Kernel end
+
+# Binary methods.
+ew(k::PerEQ, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-2 .* sin.(π .* abs.(x .- x′)).^2)
+pw(k::PerEQ, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-2 .* sin.(π .* abs.(x .- x′')).^2)
+
+# Unary methods.
+ew(::PerEQ, x::AV{<:Real}) = ones(eltype(x), length(x))
+pw(k::PerEQ, x::AV{<:Real}) = pw(k, x, x)
+
+
+
+"""
+    Exp <: Kernel
+
+The standardised Exponential kernel.
+"""
+struct Exp <: Kernel end
+
+# Binary methods
+ew(k::Exp, x::AV, x′::AV) = exp.(.-ew(Euclidean(), x, x′))
+pw(k::Exp, x::AV, x′::AV) = exp.(.-pw(Euclidean(), x, x′))
+
+# Unary methods
+ew(::Exp, x::AV) = exp.(.-ew(Euclidean(), x))
+pw(::Exp, x::AV) = exp.(.-pw(Euclidean(), x))
+
+
+
+"""
+    Matern12
+
+Equivalent to the Exponential kernel.
+"""
+const Matern12 = Exp
+
+
+
+"""
+    Matern32 <: Kernel
+
+The Matern kernel with ν = 3 / 2
+"""
+struct Matern32 <: Kernel end
+
+function _matern32(d::Real)
+    d = sqrt(3) * d
+    return (1 + d) * exp(-d)
+end
+
+# Binary methods
+ew(k::Matern32, x::AV, x′::AV) = _matern32.(ew(Euclidean(), x, x′))
+pw(k::Matern32, x::AV, x′::AV) = _matern32.(pw(Euclidean(), x, x′))
+
+# Unary methods
+ew(k::Matern32, x::AV) = _matern32.(ew(Euclidean(), x))
+pw(k::Matern32, x::AV) = _matern32.(pw(Euclidean(), x))
+
+
+
+"""
+    Matern52 <: Kernel
+
+The Matern kernel with ν = 5 / 2
+"""
+struct Matern52 <: Kernel end
+
+function _matern52(d::Real)
+    λ = sqrt(5) * d
+    return (1 + λ + λ^2 / 3) * exp(-λ)
+end
+
+_matern52(d::AbstractArray{<:Real}) = _matern52.(d)
+
+@adjoint function _matern52(d::AbstractArray{<:Real})
+    λ = sqrt(5) .* d
+    b = exp.(-λ)
+    return (1 .+ λ .+ λ.^2 ./ 3) .* b, Δ->(.-Δ .* sqrt(5) .* b .* λ .* (1 .+ λ) ./ 3,)
+end
+
+# Binary methods
+ew(k::Matern52, x::AV, x′::AV) = _matern52(ew(Euclidean(), x, x′))
+pw(k::Matern52, x::AV, x′::AV) = _matern52(pw(Euclidean(), x, x′))
+
+# Unary methods
+ew(k::Matern52, x::AV) = _matern52(ew(Euclidean(), x))
+pw(k::Matern52, x::AV) = _matern52(pw(Euclidean(), x))
+
+
+
+"""
+    RQ <: Kernel
+
+The standardised Rational Quadratic, with kurtosis `α`.
+"""
+struct RQ{Tα<:Real} <: Kernel
+    α::Tα
+end
+
+_rq(d, α) = (1 + d / (2α))^(-α)
+
+# Binary methods.
+ew(k::RQ, x::AV, x′::AV) = _rq.(ew(SqEuclidean(), x, x′), k.α)
+pw(k::RQ, x::AV, x′::AV) = _rq.(pw(SqEuclidean(), x, x′), k.α)
+
+# Unary methods.
+ew(k::RQ, x::AV) = _rq.(ew(SqEuclidean(), x), k.α)
+pw(k::RQ, x::AV) = _rq.(pw(SqEuclidean(), x), k.α)
+
+
+
+"""
+    Cosine <: Kernel
+
+Cosine Kernel with period parameter `p`.
+"""
+struct Cosine{Tp<:Real} <: Kernel
+    p::Tp
+end
+
+# Binary methods.
+ew(k::Cosine, x::AV{<:Real}, x′::AV{<:Real}) = cos.(pi.*ew(Euclidean(), x, x′) ./k.p)
+pw(k::Cosine, x::AV{<:Real}, x′::AV{<:Real}) = cos.(pi.*pw(Euclidean(), x, x′) ./k.p)
+
+# Unary methods.
+ew(k::Cosine, x::AV{<:Real}) = 1 .+ ew(Euclidean(), x)
+pw(k::Cosine, x::AV{<:Real}) = cos.(pi .* pw(Euclidean(), x) ./ k.p)
+
+
+
+"""
+    Linear{T<:Real} <: Kernel
+
+The standardised linear kernel / dot-product kernel.
+"""
+struct Linear <: Kernel end
+
+# Binary methods
+ew(k::Linear, x::AV{<:Real}, x′::AV{<:Real}) = x .* x′
+pw(k::Linear, x::AV{<:Real}, x′::AV{<:Real}) = x .* x′'
+ew(k::Linear, x::ColVecs, x′::ColVecs) = reshape(sum(x.X .* x′.X; dims=1), :)
+pw(k::Linear, x::ColVecs, x′::ColVecs) = x.X' * x′.X
+
+# Unary methods
+ew(k::Linear, x::AV{<:Real}) = x.^2
+pw(k::Linear, x::AV{<:Real}) = x .* x'
+ew(k::Linear, x::ColVecs) = reshape(sum(abs2.(x.X); dims=1), :)
+pw(k::Linear, x::ColVecs) = x.X' * x.X
+
+"""
+    LinearArd <: Kernel
+ARD linear kernel (covariance)
+```math
+k(x,x') = xᵀL⁻²x'
+```
+with length scale ``ℓ = (ℓ₁, ℓ₂, …)`` and ``L = diag(ℓ₁, ℓ₂, …)``.
+"""
+mutable struct LinearArd{T<:Real} <: Kernel
+    "Length scale"
+    ℓ::AV{T}
+    "Priors for kernel parameters"
+    priors::Array
+end
+
+LinearArd(ll::AV{T}) where T = LinearArd{T}(exp.(ll), [])
+
+ew(lin::LinearArd, x::AV, x′::AV) = dot(x./lin.ℓ, x′./lin.ℓ)
+
+
+
+"""
+    Poly{Tσ<:Real} <: Kernel
+
+Inhomogeneous Polynomial kernel. `Poly(p, σ²)` creates a `Poly{p}` with variance σ²,
+defined as
+```julia
+k(xl, xr) = (dot(xl, xr) + σ²)^p
+```
+"""
+struct Poly{p, Tσ²<:Real} <: Kernel
+    σ²::Tσ²
+end
+Poly(p::Int, σ²::Real) = Poly{p, typeof(σ²)}(σ²)
+
+_poly(k, σ², p) = (σ² + k)^p
+Zygote.@adjoint function _poly(k, σ², p)
+    y = _poly(k, σ², p)
+    return y, function(Δ)
+        d = Δ * p * y / (σ² + k)
+        return (d, d, nothing)
     end
 end
+
+# Binary methods
+ew(k::Poly{p}, x::AV, x′::AV) where {p} = _poly.(ew(Linear(), x, x′), k.σ², p)
+pw(k::Poly{p}, x::AV, x′::AV) where {p} = _poly.(pw(Linear(), x, x′), k.σ², p)
+
+# Unary methods
+ew(k::Poly{p}, x::AV) where {p} = _poly.(ew(Linear(), x), k.σ², p)
+pw(k::Poly{p}, x::AV) where {p} = _poly.(pw(Linear(), x), k.σ², p)
+
+
+
+"""
+    GammaExp
+
+The γ-Exponential kernel, 0 < γ ⩽ 2, is given by `k(xl, xr) = exp(-||xl - xr||^γ)`.
+"""
+struct GammaExp{Tγ<:Real} <: Kernel
+    γ::Tγ
+end
+
+# Binary methods
+ew(k::GammaExp, x::AV, x′::AV) = exp.(.-ew(Euclidean(), x, x′).^k.γ)
+pw(k::GammaExp, x::AV, x′::AV) = exp.(.-pw(Euclidean(), x, x′).^k.γ)
+
+# Unary methods
+ew(k::GammaExp, x::AV) = exp.(.-ew(Euclidean(), x).^k.γ)
+pw(k::GammaExp, x::AV) = exp.(.-pw(Euclidean(), x).^k.γ)
+
+
+
+"""
+    Wiener <: Kernel
+
+The standardised stationary Wiener-process kernel.
+"""
+struct Wiener <: Kernel end
+
+_wiener(x::Real, x′::Real) = min(x, x′)
+
+# Binary methods
+ew(k::Wiener, x::AV{<:Real}, x′::AV{<:Real}) = _wiener.(x, x′)
+pw(k::Wiener, x::AV{<:Real}, x′::AV{<:Real}) = _wiener.(x, x′')
+
+# Unary methods
+ew(k::Wiener, x::AV{<:Real}) = x
+pw(k::Wiener, x::AV{<:Real}) = pw(k, x, x)
+
+
+
+"""
+    WienerVelocity <: Kernel
+
+The standardised WienerVelocity kernel.
+"""
+struct WienerVelocity <: Kernel end
+
+_wiener_vel(x::Real, x′::Real) = min(x, x′)^3 / 3 + abs(x - x′) * min(x, x′)^2 / 2
+
+# Binary methods
+ew(k::WienerVelocity, x::AV{<:Real}, x′::AV{<:Real}) = _wiener_vel.(x, x′)
+pw(k::WienerVelocity, x::AV{<:Real}, x′::AV{<:Real}) = _wiener_vel.(x, x′')
+
+# Unary methods
+ew(k::WienerVelocity, x::AV{<:Real}) = ew(k, x, x)
+pw(k::WienerVelocity, x::AV{<:Real}) = pw(k, x, x)
+
+
+
+"""
+    Noise{T<:Real} <: Kernel
+
+The standardised aleatoric white-noise kernel. Isn't really a kernel, but never mind...
+"""
+struct Noise{T<:Real} <: Kernel end
+Noise() = Noise{Int}()
+
+# Binary methods.
+ew(k::Noise{T}, x::AV, x′::AV) where {T} = zeros(T, broadcast_shape(size(x), size(x′))...)
+pw(k::Noise{T}, x::AV, x′::AV) where {T} = zeros(T, length(x), length(x′))
+
+# Unary methods.
+ew(k::Noise{T}, x::AV) where {T} = ones(T, length(x))
+pw(k::Noise{T}, x::AV) where {T} = diagm(0=>ones(T, length(x)))
+
+
+"""
+    Precomputed{T<:Real} <: Kernel
+
+Using the values of a precomputed Gram matrix as a kernel.
+
+Optionally checks if the Gram matrix is positive definite by setting
+`checkpd=true`
+"""
+struct Precomputed{M<:AbstractMatrix{<:Real}} <: Kernel
+    K::M
+    function Precomputed(K::AbstractMatrix{<:Real}; checkpd=false)
+        checksquare(K)
+        checkpd && @assert isposdef(K) "M is not positive definite"
+        new{typeof(K)}(K)
+    end
+end
+
+# Binary methods.
+ew(k::Precomputed, x::AV{<:Integer}, x′::AV{<:Integer}) = [k.K[p, q] for (p, q) in zip(x, x′)]
+pw(k::Precomputed, x::AV{<:Integer}, x′::AV{<:Integer}) = k.K[x, x′]
+
+# Unary methods.
+ew(k::Precomputed, x::AV{<:Integer}) = diag(k.K)[x]
+pw(k::Precomputed, x::AV{<:Integer}) = k.K[x,x]
+
+precomputed(K::AbstractMatrix) = Precomputed(K)
+export precomputed
+
+
+
+#
+# Composite Kernels
+#
+
+"""
+    Sum{Tkl<:Kernel, Tkr<:Kernel} <: Kernel
+
+Represents the sum of two kernels `kl` and `kr` s.t. `k(x, x′) = kl(x, x′) + kr(x, x′)`.
+"""
+struct Sum{Tkl<:Kernel, Tkr<:Kernel} <: Kernel
+    kl::Tkl
+    kr::Tkr
+end
+
++(kl::Kernel, kr::Kernel) = Sum(kl, kr)
+
+# Binary methods
+ew(k::Sum, x::AV, x′::AV) = ew(k.kl, x, x′) + ew(k.kr, x, x′)
+pw(k::Sum, x::AV, x′::AV) = pw(k.kl, x, x′) + pw(k.kr, x, x′)
+
+# Unary methods
+ew(k::Sum, x::AV) = ew(k.kl, x) + ew(k.kr, x)
+pw(k::Sum, x::AV) = pw(k.kl, x) + pw(k.kr, x)
+
+
+
+"""
+    Product{Tkl<:Kernel, Tkr<:Kernel} <: Kernel
+
+Represents the product of two kernels `kl` and `kr` s.t. `k(x, x′) = kl(x, x′) kr(x, x′)`.
+"""
+struct Product{Tkl<:Kernel, Tkr<:Kernel} <: Kernel
+    kl::Tkl
+    kr::Tkr
+end
+
+*(kl::Kernel, kr::Kernel) = Product(kl, kr)
+
+# Binary methods
+ew(k::Product, x::AV, x′::AV) = ew(k.kl, x, x′) .* ew(k.kr, x, x′)
+pw(k::Product, x::AV, x′::AV) = pw(k.kl, x, x′) .* pw(k.kr, x, x′)
+
+# Unary methods
+ew(k::Product, x::AV) = ew(k.kl, x) .* ew(k.kr, x)
+pw(k::Product, x::AV) = pw(k.kl, x) .* pw(k.kr, x)
+
+
+
+"""
+    Scaled{Tσ²<:Real, Tk<:Kernel} <: Kernel
+
+Scale the variance of `Kernel` `k` by `σ²` s.t. `(σ² * k)(x, x′) = σ² * k(x, x′)`.
+"""
+struct Scaled{Tσ²<:Real, Tk<:Kernel} <: Kernel
+    σ²::Tσ²
+    k::Tk
+end
+
+*(σ²::Real, k::Kernel) = Scaled(σ², k)
+*(k::Kernel, σ²) = σ² * k
+
+# Binary methods.
+ew(k::Scaled, x::AV, x′::AV) = k.σ² .* ew(k.k, x, x′)
+pw(k::Scaled, x::AV, x′::AV) = k.σ² .* pw(k.k, x, x′)
+
+# Unary methods.
+ew(k::Scaled, x::AV) = k.σ² .* ew(k.k, x)
+pw(k::Scaled, x::AV) = k.σ² .* pw(k.k, x)
+
+
+
+"""
+    Stretched{Tk<:Kernel} <: Kernel
+
+Apply a length scale to a kernel. Specifically, `k(x, x′) = k(a * x, a * x′)`.
+"""
+struct Stretched{Ta<:Union{Real, AV{<:Real}, AM{<:Real}}, Tk<:Kernel} <: Kernel
+    a::Ta
+    k::Tk
+end
+
+stretch(k::Kernel, a::Union{Real, AV{<:Real}, AM{<:Real}}) = Stretched(a, k)
+
+# Binary methods (scalar `a`, scalar-valued input)
+ew(k::Stretched{<:Real}, x::AV{<:Real}, x′::AV{<:Real}) = ew(k.k, k.a .* x, k.a .* x′)
+pw(k::Stretched{<:Real}, x::AV{<:Real}, x′::AV{<:Real}) = pw(k.k, k.a .* x, k.a .* x′)
+
+# Unary methods (scalar)
+ew(k::Stretched{<:Real}, x::AV{<:Real}) = ew(k.k, k.a .* x)
+pw(k::Stretched{<:Real}, x::AV{<:Real}) = pw(k.k, k.a .* x)
+
+# Binary methods (scalar and vector `a`, vector-valued input)
+function ew(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs, x′::ColVecs)
+    return ew(k.k, ColVecs(k.a .* x.X), ColVecs(k.a .* x′.X))
+end
+function pw(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs, x′::ColVecs)
+    return pw(k.k, ColVecs(k.a .* x.X), ColVecs(k.a .* x′.X))
+end
+
+# Unary methods (scalar and vector `a`, vector-valued input)
+ew(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs) = ew(k.k, ColVecs(k.a .* x.X))
+pw(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs) = pw(k.k, ColVecs(k.a .* x.X))
+
+# Binary methods (matrix `a`, vector-valued input)
+function ew(k::Stretched{<:AM{<:Real}}, x::ColVecs, x′::ColVecs)
+    return ew(k.k, ColVecs(k.a * x.X), ColVecs(k.a * x′.X))
+end
+function pw(k::Stretched{<:AM{<:Real}}, x::ColVecs, x′::ColVecs)
+    return pw(k.k, ColVecs(k.a * x.X), ColVecs(k.a * x′.X))
+end
+
+# Unary methods (scalar and vector `a`, vector-valued input)
+ew(k::Stretched{<:AM{<:Real}}, x::ColVecs) = ew(k.k, ColVecs(k.a * x.X))
+pw(k::Stretched{<:AM{<:Real}}, x::ColVecs) = pw(k.k, ColVecs(k.a * x.X))
+
+# Create convenience versions of each of the kernels that accept a length scale.
+for (k, K) in (
+    (:eq, :EQ),
+    (:exponential, :Exp),
+    (:matern12, :Matern12),
+    (:matern32, :Matern32),
+    (:matern52, :Matern52),
+    (:linear, :Linear),
+    (:wiener, :Wiener),
+    (:wiener_velocity, :WienerVelocity),
+)
+    @eval $k() = $K()
+    @eval $k(a::Union{Real, AV{<:Real}, AM{<:Real}}) = stretch($k(), a)
+    @eval export $k
+end
+
+rq(α) = RQ(α)
+rq(α, l) = stretch(rq(α), l)
+export rq
+
+cosine(p) = Cosine(p)
+cosine(p, l) = stretch(cosine(p), l)
+export cosine
+
+γ_exponential(γ::Real) = GammaExp(γ)
+γ_exponential(γ::Real, l::Union{Real, AV{<:Real}, AM{<:Real}}) = stretch(GammaExp(γ), l)
+export γ_exponential
+
+poly(p::Int, σ²::Real) = Poly(p, σ²)
+poly(p::Int, σ²::Real, l::Union{Real, AV{<:Real}, AM{<:Real}}) = stretch(Poly(p, σ²), l)
+export poly
+
+
+

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -1,0 +1,37 @@
+abstract type Kernel end
+
+
+import Base: +, *, zero, cos
+using Distances: sqeuclidean, SqEuclidean, Euclidean
+using Base.Broadcast: broadcast_shape
+using LinearAlgebra: isposdef, checksquare
+
+const AV{T} = AbstractVector{T}
+const AM{T} = AbstractMatrix{T}
+const AVM{T} = AbstractVecOrMat{T}
+
+export
+    Kernel,
+    ZeroKernel,
+    zero
+abstract type Kernel end
+
+
+
+"""
+    ZeroKernel <: Kernel
+A rank 0 `Kernel` that always returns zero.
+"""
+struct ZeroKernel{T<:Real} <: Kernel end
+ZeroKernel() = ZeroKernel{Float64}()
+zero(::Kernel) = ZeroKernel()
+
+function (k::ZeroKernel{T})(x::AV, x′::AV; type=:pairwise) where {T}
+    if type == :elementwise
+        return zeros(T, broadcast_shape(size(x), size(x′)))
+    elseif type == :pairwise
+        return zeros(T, length(x), length(x′))
+    else
+        @error "`$type` is not a valid kernel application type" 
+    end
+end

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -184,43 +184,43 @@ pw(k::Matern52, x::AV) = _matern52(pw(Euclidean(), x))
 
 
 
-# """
-#     RQ <: Kernel
+"""
+    RQ <: Kernel
 
-# The standardised Rational Quadratic, with kurtosis `α`.
-# """
-# struct RQ{Tα<:Real} <: Kernel
-#     α::Tα
-# end
+The standardised Rational Quadratic, with kurtosis `α`.
+"""
+struct RQ{Tα<:Real} <: Kernel
+    α::Tα
+end
 
-# _rq(d, α) = (1 + d / (2α))^(-α)
+_rq(d, α) = (1 + d / (2α))^(-α)
 
-# # Binary methods.
-# ew(k::RQ, x::AV, x′::AV) = _rq.(ew(SqEuclidean(), x, x′), k.α)
-# pw(k::RQ, x::AV, x′::AV) = _rq.(pw(SqEuclidean(), x, x′), k.α)
+# Binary methods.
+ew(k::RQ, x::AV, x′::AV) = _rq.(ew(SqEuclidean(), x, x′), k.α)
+pw(k::RQ, x::AV, x′::AV) = _rq.(pw(SqEuclidean(), x, x′), k.α)
 
-# # Unary methods.
-# ew(k::RQ, x::AV) = _rq.(ew(SqEuclidean(), x), k.α)
-# pw(k::RQ, x::AV) = _rq.(pw(SqEuclidean(), x), k.α)
+# Unary methods.
+ew(k::RQ, x::AV) = _rq.(ew(SqEuclidean(), x), k.α)
+pw(k::RQ, x::AV) = _rq.(pw(SqEuclidean(), x), k.α)
 
 
 
-# """
-#     Cosine <: Kernel
+"""
+    Cosine <: Kernel
 
-# Cosine Kernel with period parameter `p`.
-# """
-# struct Cosine{Tp<:Real} <: Kernel
-#     p::Tp
-# end
+Cosine Kernel with period parameter `p`.
+"""
+struct Cosine{Tp<:Real} <: Kernel
+    p::Tp
+end
 
-# # Binary methods.
-# ew(k::Cosine, x::AV{<:Real}, x′::AV{<:Real}) = cos.(pi.*ew(Euclidean(), x, x′) ./k.p)
-# pw(k::Cosine, x::AV{<:Real}, x′::AV{<:Real}) = cos.(pi.*pw(Euclidean(), x, x′) ./k.p)
+# Binary methods.
+ew(k::Cosine, x::AV{<:Real}, x′::AV{<:Real}) = cos.(pi.*ew(Euclidean(), x, x′) ./k.p)
+pw(k::Cosine, x::AV{<:Real}, x′::AV{<:Real}) = cos.(pi.*pw(Euclidean(), x, x′) ./k.p)
 
-# # Unary methods.
-# ew(k::Cosine, x::AV{<:Real}) = 1 .+ ew(Euclidean(), x)
-# pw(k::Cosine, x::AV{<:Real}) = cos.(pi .* pw(Euclidean(), x) ./ k.p)
+# Unary methods.
+ew(k::Cosine, x::AV{<:Real}) = 1 .+ ew(Euclidean(), x)
+pw(k::Cosine, x::AV{<:Real}) = cos.(pi .* pw(Euclidean(), x) ./ k.p)
 
 
 

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -264,36 +264,36 @@ ew(lin::LinearArd, x::AV, x′::AV) = dot(x./lin.ℓ, x′./lin.ℓ)
 
 
 
-# """
-#     Poly{Tσ<:Real} <: Kernel
+"""
+    Poly{Tσ<:Real} <: Kernel
 
-# Inhomogeneous Polynomial kernel. `Poly(p, σ²)` creates a `Poly{p}` with variance σ²,
-# defined as
-# ```julia
-# k(xl, xr) = (dot(xl, xr) + σ²)^p
-# ```
-# """
-# struct Poly{p, Tσ²<:Real} <: Kernel
-#     σ²::Tσ²
-# end
-# Poly(p::Int, σ²::Real) = Poly{p, typeof(σ²)}(σ²)
+Inhomogeneous Polynomial kernel. `Poly(p, σ²)` creates a `Poly{p}` with variance σ²,
+defined as
+```julia
+k(xl, xr) = (dot(xl, xr) + σ²)^p
+```
+"""
+struct Poly{p, Tσ²<:Real} <: Kernel
+    σ²::Tσ²
+end
+Poly(p::Int, σ²::Real) = Poly{p, typeof(σ²)}(σ²)
 
-# _poly(k, σ², p) = (σ² + k)^p
-# Zygote.@adjoint function _poly(k, σ², p)
-#     y = _poly(k, σ², p)
-#     return y, function(Δ)
-#         d = Δ * p * y / (σ² + k)
-#         return (d, d, nothing)
-#     end
-# end
+_poly(k, σ², p) = (σ² + k)^p
+Zygote.@adjoint function _poly(k, σ², p)
+    y = _poly(k, σ², p)
+    return y, function(Δ)
+        d = Δ * p * y / (σ² + k)
+        return (d, d, nothing)
+    end
+end
 
-# # Binary methods
-# ew(k::Poly{p}, x::AV, x′::AV) where {p} = _poly.(ew(Linear(), x, x′), k.σ², p)
-# pw(k::Poly{p}, x::AV, x′::AV) where {p} = _poly.(pw(Linear(), x, x′), k.σ², p)
+# Binary methods
+ew(k::Poly{p}, x::AV, x′::AV) where {p} = _poly.(ew(Linear(), x, x′), k.σ², p)
+pw(k::Poly{p}, x::AV, x′::AV) where {p} = _poly.(pw(Linear(), x, x′), k.σ², p)
 
-# # Unary methods
-# ew(k::Poly{p}, x::AV) where {p} = _poly.(ew(Linear(), x), k.σ², p)
-# pw(k::Poly{p}, x::AV) where {p} = _poly.(pw(Linear(), x), k.σ², p)
+# Unary methods
+ew(k::Poly{p}, x::AV) where {p} = _poly.(ew(Linear(), x), k.σ², p)
+pw(k::Poly{p}, x::AV) where {p} = _poly.(pw(Linear(), x), k.σ², p)
 
 
 

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -9,17 +9,11 @@ using Base.Broadcast: broadcast_shape
 using LinearAlgebra: isposdef, checksquare
 using Zygote: @adjoint
 
-const AV{T} = AbstractVector{T}
-const AM{T} = AbstractMatrix{T}
-const AVM{T} = AbstractVecOrMat{T}
-
 abstract type Kernel end
 
 #
 # Base Kernels
 #
-
-include(joinpath("utils", "distances.jl"))
 
 """
     ZeroKernel <: Kernel
@@ -95,37 +89,37 @@ pw(::EQ, x::AV) = exp.(.-pw(SqEuclidean(), x) ./ 2)
 
 
 
-# """
-#     PerEQ
+"""
+    PerEQ
 
-# The usual periodic kernel derived by mapping the input domain onto the unit circle.
-# """
-# struct PerEQ <: Kernel end
+The usual periodic kernel derived by mapping the input domain onto the unit circle.
+"""
+struct PerEQ <: Kernel end
 
-# # Binary methods.
-# ew(k::PerEQ, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-2 .* sin.(π .* abs.(x .- x′)).^2)
-# pw(k::PerEQ, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-2 .* sin.(π .* abs.(x .- x′')).^2)
+# Binary methods.
+ew(k::PerEQ, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-2 .* sin.(π .* abs.(x .- x′)).^2)
+pw(k::PerEQ, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-2 .* sin.(π .* abs.(x .- x′')).^2)
 
-# # Unary methods.
-# ew(::PerEQ, x::AV{<:Real}) = ones(eltype(x), length(x))
-# pw(k::PerEQ, x::AV{<:Real}) = pw(k, x, x)
+# Unary methods.
+ew(::PerEQ, x::AV{<:Real}) = ones(eltype(x), length(x))
+pw(k::PerEQ, x::AV{<:Real}) = pw(k, x, x)
 
 
 
-# """
-#     Exp <: Kernel
+"""
+    Exp <: Kernel
 
-# The standardised Exponential kernel.
-# """
-# struct Exp <: Kernel end
+The standardised Exponential kernel.
+"""
+struct Exp <: Kernel end
 
-# # Binary methods
-# ew(k::Exp, x::AV, x′::AV) = exp.(.-ew(Euclidean(), x, x′))
-# pw(k::Exp, x::AV, x′::AV) = exp.(.-pw(Euclidean(), x, x′))
+# Binary methods
+ew(k::Exp, x::AV, x′::AV) = exp.(.-ew(Euclidean(), x, x′))
+pw(k::Exp, x::AV, x′::AV) = exp.(.-pw(Euclidean(), x, x′))
 
-# # Unary methods
-# ew(::Exp, x::AV) = exp.(.-ew(Euclidean(), x))
-# pw(::Exp, x::AV) = exp.(.-pw(Euclidean(), x))
+# Unary methods
+ew(::Exp, x::AV) = exp.(.-ew(Euclidean(), x))
+pw(::Exp, x::AV) = exp.(.-pw(Euclidean(), x))
 
 
 

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -19,6 +19,8 @@ abstract type Kernel end
 # Base Kernels
 #
 
+include(joinpath("utils", "distances.jl"))
+
 """
     ZeroKernel <: Kernel
 
@@ -93,464 +95,464 @@ pw(::EQ, x::AV) = exp.(.-pw(SqEuclidean(), x) ./ 2)
 
 
 
-"""
-    PerEQ
+# """
+#     PerEQ
 
-The usual periodic kernel derived by mapping the input domain onto the unit circle.
-"""
-struct PerEQ <: Kernel end
+# The usual periodic kernel derived by mapping the input domain onto the unit circle.
+# """
+# struct PerEQ <: Kernel end
 
-# Binary methods.
-ew(k::PerEQ, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-2 .* sin.(π .* abs.(x .- x′)).^2)
-pw(k::PerEQ, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-2 .* sin.(π .* abs.(x .- x′')).^2)
+# # Binary methods.
+# ew(k::PerEQ, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-2 .* sin.(π .* abs.(x .- x′)).^2)
+# pw(k::PerEQ, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-2 .* sin.(π .* abs.(x .- x′')).^2)
 
-# Unary methods.
-ew(::PerEQ, x::AV{<:Real}) = ones(eltype(x), length(x))
-pw(k::PerEQ, x::AV{<:Real}) = pw(k, x, x)
+# # Unary methods.
+# ew(::PerEQ, x::AV{<:Real}) = ones(eltype(x), length(x))
+# pw(k::PerEQ, x::AV{<:Real}) = pw(k, x, x)
 
 
 
-"""
-    Exp <: Kernel
+# """
+#     Exp <: Kernel
 
-The standardised Exponential kernel.
-"""
-struct Exp <: Kernel end
+# The standardised Exponential kernel.
+# """
+# struct Exp <: Kernel end
 
-# Binary methods
-ew(k::Exp, x::AV, x′::AV) = exp.(.-ew(Euclidean(), x, x′))
-pw(k::Exp, x::AV, x′::AV) = exp.(.-pw(Euclidean(), x, x′))
+# # Binary methods
+# ew(k::Exp, x::AV, x′::AV) = exp.(.-ew(Euclidean(), x, x′))
+# pw(k::Exp, x::AV, x′::AV) = exp.(.-pw(Euclidean(), x, x′))
 
-# Unary methods
-ew(::Exp, x::AV) = exp.(.-ew(Euclidean(), x))
-pw(::Exp, x::AV) = exp.(.-pw(Euclidean(), x))
+# # Unary methods
+# ew(::Exp, x::AV) = exp.(.-ew(Euclidean(), x))
+# pw(::Exp, x::AV) = exp.(.-pw(Euclidean(), x))
 
 
 
-"""
-    Matern12
+# """
+#     Matern12
 
-Equivalent to the Exponential kernel.
-"""
-const Matern12 = Exp
+# Equivalent to the Exponential kernel.
+# """
+# const Matern12 = Exp
 
 
 
-"""
-    Matern32 <: Kernel
+# """
+#     Matern32 <: Kernel
 
-The Matern kernel with ν = 3 / 2
-"""
-struct Matern32 <: Kernel end
+# The Matern kernel with ν = 3 / 2
+# """
+# struct Matern32 <: Kernel end
 
-function _matern32(d::Real)
-    d = sqrt(3) * d
-    return (1 + d) * exp(-d)
-end
+# function _matern32(d::Real)
+#     d = sqrt(3) * d
+#     return (1 + d) * exp(-d)
+# end
 
-# Binary methods
-ew(k::Matern32, x::AV, x′::AV) = _matern32.(ew(Euclidean(), x, x′))
-pw(k::Matern32, x::AV, x′::AV) = _matern32.(pw(Euclidean(), x, x′))
+# # Binary methods
+# ew(k::Matern32, x::AV, x′::AV) = _matern32.(ew(Euclidean(), x, x′))
+# pw(k::Matern32, x::AV, x′::AV) = _matern32.(pw(Euclidean(), x, x′))
 
-# Unary methods
-ew(k::Matern32, x::AV) = _matern32.(ew(Euclidean(), x))
-pw(k::Matern32, x::AV) = _matern32.(pw(Euclidean(), x))
+# # Unary methods
+# ew(k::Matern32, x::AV) = _matern32.(ew(Euclidean(), x))
+# pw(k::Matern32, x::AV) = _matern32.(pw(Euclidean(), x))
 
 
 
-"""
-    Matern52 <: Kernel
+# """
+#     Matern52 <: Kernel
 
-The Matern kernel with ν = 5 / 2
-"""
-struct Matern52 <: Kernel end
+# The Matern kernel with ν = 5 / 2
+# """
+# struct Matern52 <: Kernel end
 
-function _matern52(d::Real)
-    λ = sqrt(5) * d
-    return (1 + λ + λ^2 / 3) * exp(-λ)
-end
+# function _matern52(d::Real)
+#     λ = sqrt(5) * d
+#     return (1 + λ + λ^2 / 3) * exp(-λ)
+# end
 
-_matern52(d::AbstractArray{<:Real}) = _matern52.(d)
+# _matern52(d::AbstractArray{<:Real}) = _matern52.(d)
 
-@adjoint function _matern52(d::AbstractArray{<:Real})
-    λ = sqrt(5) .* d
-    b = exp.(-λ)
-    return (1 .+ λ .+ λ.^2 ./ 3) .* b, Δ->(.-Δ .* sqrt(5) .* b .* λ .* (1 .+ λ) ./ 3,)
-end
+# @adjoint function _matern52(d::AbstractArray{<:Real})
+#     λ = sqrt(5) .* d
+#     b = exp.(-λ)
+#     return (1 .+ λ .+ λ.^2 ./ 3) .* b, Δ->(.-Δ .* sqrt(5) .* b .* λ .* (1 .+ λ) ./ 3,)
+# end
 
-# Binary methods
-ew(k::Matern52, x::AV, x′::AV) = _matern52(ew(Euclidean(), x, x′))
-pw(k::Matern52, x::AV, x′::AV) = _matern52(pw(Euclidean(), x, x′))
+# # Binary methods
+# ew(k::Matern52, x::AV, x′::AV) = _matern52(ew(Euclidean(), x, x′))
+# pw(k::Matern52, x::AV, x′::AV) = _matern52(pw(Euclidean(), x, x′))
 
-# Unary methods
-ew(k::Matern52, x::AV) = _matern52(ew(Euclidean(), x))
-pw(k::Matern52, x::AV) = _matern52(pw(Euclidean(), x))
+# # Unary methods
+# ew(k::Matern52, x::AV) = _matern52(ew(Euclidean(), x))
+# pw(k::Matern52, x::AV) = _matern52(pw(Euclidean(), x))
 
 
 
-"""
-    RQ <: Kernel
+# """
+#     RQ <: Kernel
 
-The standardised Rational Quadratic, with kurtosis `α`.
-"""
-struct RQ{Tα<:Real} <: Kernel
-    α::Tα
-end
-
-_rq(d, α) = (1 + d / (2α))^(-α)
-
-# Binary methods.
-ew(k::RQ, x::AV, x′::AV) = _rq.(ew(SqEuclidean(), x, x′), k.α)
-pw(k::RQ, x::AV, x′::AV) = _rq.(pw(SqEuclidean(), x, x′), k.α)
+# The standardised Rational Quadratic, with kurtosis `α`.
+# """
+# struct RQ{Tα<:Real} <: Kernel
+#     α::Tα
+# end
+
+# _rq(d, α) = (1 + d / (2α))^(-α)
+
+# # Binary methods.
+# ew(k::RQ, x::AV, x′::AV) = _rq.(ew(SqEuclidean(), x, x′), k.α)
+# pw(k::RQ, x::AV, x′::AV) = _rq.(pw(SqEuclidean(), x, x′), k.α)
 
-# Unary methods.
-ew(k::RQ, x::AV) = _rq.(ew(SqEuclidean(), x), k.α)
-pw(k::RQ, x::AV) = _rq.(pw(SqEuclidean(), x), k.α)
+# # Unary methods.
+# ew(k::RQ, x::AV) = _rq.(ew(SqEuclidean(), x), k.α)
+# pw(k::RQ, x::AV) = _rq.(pw(SqEuclidean(), x), k.α)
 
 
 
-"""
-    Cosine <: Kernel
+# """
+#     Cosine <: Kernel
 
-Cosine Kernel with period parameter `p`.
-"""
-struct Cosine{Tp<:Real} <: Kernel
-    p::Tp
-end
+# Cosine Kernel with period parameter `p`.
+# """
+# struct Cosine{Tp<:Real} <: Kernel
+#     p::Tp
+# end
 
-# Binary methods.
-ew(k::Cosine, x::AV{<:Real}, x′::AV{<:Real}) = cos.(pi.*ew(Euclidean(), x, x′) ./k.p)
-pw(k::Cosine, x::AV{<:Real}, x′::AV{<:Real}) = cos.(pi.*pw(Euclidean(), x, x′) ./k.p)
+# # Binary methods.
+# ew(k::Cosine, x::AV{<:Real}, x′::AV{<:Real}) = cos.(pi.*ew(Euclidean(), x, x′) ./k.p)
+# pw(k::Cosine, x::AV{<:Real}, x′::AV{<:Real}) = cos.(pi.*pw(Euclidean(), x, x′) ./k.p)
 
-# Unary methods.
-ew(k::Cosine, x::AV{<:Real}) = 1 .+ ew(Euclidean(), x)
-pw(k::Cosine, x::AV{<:Real}) = cos.(pi .* pw(Euclidean(), x) ./ k.p)
+# # Unary methods.
+# ew(k::Cosine, x::AV{<:Real}) = 1 .+ ew(Euclidean(), x)
+# pw(k::Cosine, x::AV{<:Real}) = cos.(pi .* pw(Euclidean(), x) ./ k.p)
 
 
 
-"""
-    Linear{T<:Real} <: Kernel
+# """
+#     Linear{T<:Real} <: Kernel
 
-The standardised linear kernel / dot-product kernel.
-"""
-struct Linear <: Kernel end
+# The standardised linear kernel / dot-product kernel.
+# """
+# struct Linear <: Kernel end
 
-# Binary methods
-ew(k::Linear, x::AV{<:Real}, x′::AV{<:Real}) = x .* x′
-pw(k::Linear, x::AV{<:Real}, x′::AV{<:Real}) = x .* x′'
-ew(k::Linear, x::ColVecs, x′::ColVecs) = reshape(sum(x.X .* x′.X; dims=1), :)
-pw(k::Linear, x::ColVecs, x′::ColVecs) = x.X' * x′.X
+# # Binary methods
+# ew(k::Linear, x::AV{<:Real}, x′::AV{<:Real}) = x .* x′
+# pw(k::Linear, x::AV{<:Real}, x′::AV{<:Real}) = x .* x′'
+# ew(k::Linear, x::ColVecs, x′::ColVecs) = reshape(sum(x.X .* x′.X; dims=1), :)
+# pw(k::Linear, x::ColVecs, x′::ColVecs) = x.X' * x′.X
 
-# Unary methods
-ew(k::Linear, x::AV{<:Real}) = x.^2
-pw(k::Linear, x::AV{<:Real}) = x .* x'
-ew(k::Linear, x::ColVecs) = reshape(sum(abs2.(x.X); dims=1), :)
-pw(k::Linear, x::ColVecs) = x.X' * x.X
+# # Unary methods
+# ew(k::Linear, x::AV{<:Real}) = x.^2
+# pw(k::Linear, x::AV{<:Real}) = x .* x'
+# ew(k::Linear, x::ColVecs) = reshape(sum(abs2.(x.X); dims=1), :)
+# pw(k::Linear, x::ColVecs) = x.X' * x.X
 
-"""
-    LinearArd <: Kernel
-ARD linear kernel (covariance)
-```math
-k(x,x') = xᵀL⁻²x'
-```
-with length scale ``ℓ = (ℓ₁, ℓ₂, …)`` and ``L = diag(ℓ₁, ℓ₂, …)``.
-"""
-mutable struct LinearArd{T<:Real} <: Kernel
-    "Length scale"
-    ℓ::AV{T}
-    "Priors for kernel parameters"
-    priors::Array
-end
+# """
+#     LinearArd <: Kernel
+# ARD linear kernel (covariance)
+# ```math
+# k(x,x') = xᵀL⁻²x'
+# ```
+# with length scale ``ℓ = (ℓ₁, ℓ₂, …)`` and ``L = diag(ℓ₁, ℓ₂, …)``.
+# """
+# mutable struct LinearArd{T<:Real} <: Kernel
+#     "Length scale"
+#     ℓ::AV{T}
+#     "Priors for kernel parameters"
+#     priors::Array
+# end
 
-LinearArd(ll::AV{T}) where T = LinearArd{T}(exp.(ll), [])
+# LinearArd(ll::AV{T}) where T = LinearArd{T}(exp.(ll), [])
 
-ew(lin::LinearArd, x::AV, x′::AV) = dot(x./lin.ℓ, x′./lin.ℓ)
+# ew(lin::LinearArd, x::AV, x′::AV) = dot(x./lin.ℓ, x′./lin.ℓ)
 
 
 
-"""
-    Poly{Tσ<:Real} <: Kernel
+# """
+#     Poly{Tσ<:Real} <: Kernel
 
-Inhomogeneous Polynomial kernel. `Poly(p, σ²)` creates a `Poly{p}` with variance σ²,
-defined as
-```julia
-k(xl, xr) = (dot(xl, xr) + σ²)^p
-```
-"""
-struct Poly{p, Tσ²<:Real} <: Kernel
-    σ²::Tσ²
-end
-Poly(p::Int, σ²::Real) = Poly{p, typeof(σ²)}(σ²)
+# Inhomogeneous Polynomial kernel. `Poly(p, σ²)` creates a `Poly{p}` with variance σ²,
+# defined as
+# ```julia
+# k(xl, xr) = (dot(xl, xr) + σ²)^p
+# ```
+# """
+# struct Poly{p, Tσ²<:Real} <: Kernel
+#     σ²::Tσ²
+# end
+# Poly(p::Int, σ²::Real) = Poly{p, typeof(σ²)}(σ²)
 
-_poly(k, σ², p) = (σ² + k)^p
-Zygote.@adjoint function _poly(k, σ², p)
-    y = _poly(k, σ², p)
-    return y, function(Δ)
-        d = Δ * p * y / (σ² + k)
-        return (d, d, nothing)
-    end
-end
+# _poly(k, σ², p) = (σ² + k)^p
+# Zygote.@adjoint function _poly(k, σ², p)
+#     y = _poly(k, σ², p)
+#     return y, function(Δ)
+#         d = Δ * p * y / (σ² + k)
+#         return (d, d, nothing)
+#     end
+# end
 
-# Binary methods
-ew(k::Poly{p}, x::AV, x′::AV) where {p} = _poly.(ew(Linear(), x, x′), k.σ², p)
-pw(k::Poly{p}, x::AV, x′::AV) where {p} = _poly.(pw(Linear(), x, x′), k.σ², p)
+# # Binary methods
+# ew(k::Poly{p}, x::AV, x′::AV) where {p} = _poly.(ew(Linear(), x, x′), k.σ², p)
+# pw(k::Poly{p}, x::AV, x′::AV) where {p} = _poly.(pw(Linear(), x, x′), k.σ², p)
 
-# Unary methods
-ew(k::Poly{p}, x::AV) where {p} = _poly.(ew(Linear(), x), k.σ², p)
-pw(k::Poly{p}, x::AV) where {p} = _poly.(pw(Linear(), x), k.σ², p)
+# # Unary methods
+# ew(k::Poly{p}, x::AV) where {p} = _poly.(ew(Linear(), x), k.σ², p)
+# pw(k::Poly{p}, x::AV) where {p} = _poly.(pw(Linear(), x), k.σ², p)
 
 
 
-"""
-    GammaExp
+# """
+#     GammaExp
 
-The γ-Exponential kernel, 0 < γ ⩽ 2, is given by `k(xl, xr) = exp(-||xl - xr||^γ)`.
-"""
-struct GammaExp{Tγ<:Real} <: Kernel
-    γ::Tγ
-end
+# The γ-Exponential kernel, 0 < γ ⩽ 2, is given by `k(xl, xr) = exp(-||xl - xr||^γ)`.
+# """
+# struct GammaExp{Tγ<:Real} <: Kernel
+#     γ::Tγ
+# end
 
-# Binary methods
-ew(k::GammaExp, x::AV, x′::AV) = exp.(.-ew(Euclidean(), x, x′).^k.γ)
-pw(k::GammaExp, x::AV, x′::AV) = exp.(.-pw(Euclidean(), x, x′).^k.γ)
+# # Binary methods
+# ew(k::GammaExp, x::AV, x′::AV) = exp.(.-ew(Euclidean(), x, x′).^k.γ)
+# pw(k::GammaExp, x::AV, x′::AV) = exp.(.-pw(Euclidean(), x, x′).^k.γ)
 
-# Unary methods
-ew(k::GammaExp, x::AV) = exp.(.-ew(Euclidean(), x).^k.γ)
-pw(k::GammaExp, x::AV) = exp.(.-pw(Euclidean(), x).^k.γ)
+# # Unary methods
+# ew(k::GammaExp, x::AV) = exp.(.-ew(Euclidean(), x).^k.γ)
+# pw(k::GammaExp, x::AV) = exp.(.-pw(Euclidean(), x).^k.γ)
 
 
 
-"""
-    Wiener <: Kernel
+# """
+#     Wiener <: Kernel
 
-The standardised stationary Wiener-process kernel.
-"""
-struct Wiener <: Kernel end
+# The standardised stationary Wiener-process kernel.
+# """
+# struct Wiener <: Kernel end
 
-_wiener(x::Real, x′::Real) = min(x, x′)
+# _wiener(x::Real, x′::Real) = min(x, x′)
 
-# Binary methods
-ew(k::Wiener, x::AV{<:Real}, x′::AV{<:Real}) = _wiener.(x, x′)
-pw(k::Wiener, x::AV{<:Real}, x′::AV{<:Real}) = _wiener.(x, x′')
+# # Binary methods
+# ew(k::Wiener, x::AV{<:Real}, x′::AV{<:Real}) = _wiener.(x, x′)
+# pw(k::Wiener, x::AV{<:Real}, x′::AV{<:Real}) = _wiener.(x, x′')
 
-# Unary methods
-ew(k::Wiener, x::AV{<:Real}) = x
-pw(k::Wiener, x::AV{<:Real}) = pw(k, x, x)
+# # Unary methods
+# ew(k::Wiener, x::AV{<:Real}) = x
+# pw(k::Wiener, x::AV{<:Real}) = pw(k, x, x)
 
 
 
-"""
-    WienerVelocity <: Kernel
+# """
+#     WienerVelocity <: Kernel
 
-The standardised WienerVelocity kernel.
-"""
-struct WienerVelocity <: Kernel end
+# The standardised WienerVelocity kernel.
+# """
+# struct WienerVelocity <: Kernel end
 
-_wiener_vel(x::Real, x′::Real) = min(x, x′)^3 / 3 + abs(x - x′) * min(x, x′)^2 / 2
+# _wiener_vel(x::Real, x′::Real) = min(x, x′)^3 / 3 + abs(x - x′) * min(x, x′)^2 / 2
 
-# Binary methods
-ew(k::WienerVelocity, x::AV{<:Real}, x′::AV{<:Real}) = _wiener_vel.(x, x′)
-pw(k::WienerVelocity, x::AV{<:Real}, x′::AV{<:Real}) = _wiener_vel.(x, x′')
+# # Binary methods
+# ew(k::WienerVelocity, x::AV{<:Real}, x′::AV{<:Real}) = _wiener_vel.(x, x′)
+# pw(k::WienerVelocity, x::AV{<:Real}, x′::AV{<:Real}) = _wiener_vel.(x, x′')
 
-# Unary methods
-ew(k::WienerVelocity, x::AV{<:Real}) = ew(k, x, x)
-pw(k::WienerVelocity, x::AV{<:Real}) = pw(k, x, x)
+# # Unary methods
+# ew(k::WienerVelocity, x::AV{<:Real}) = ew(k, x, x)
+# pw(k::WienerVelocity, x::AV{<:Real}) = pw(k, x, x)
 
 
 
-"""
-    Noise{T<:Real} <: Kernel
+# """
+#     Noise{T<:Real} <: Kernel
 
-The standardised aleatoric white-noise kernel. Isn't really a kernel, but never mind...
-"""
-struct Noise{T<:Real} <: Kernel end
-Noise() = Noise{Int}()
+# The standardised aleatoric white-noise kernel. Isn't really a kernel, but never mind...
+# """
+# struct Noise{T<:Real} <: Kernel end
+# Noise() = Noise{Int}()
 
-# Binary methods.
-ew(k::Noise{T}, x::AV, x′::AV) where {T} = zeros(T, broadcast_shape(size(x), size(x′))...)
-pw(k::Noise{T}, x::AV, x′::AV) where {T} = zeros(T, length(x), length(x′))
+# # Binary methods.
+# ew(k::Noise{T}, x::AV, x′::AV) where {T} = zeros(T, broadcast_shape(size(x), size(x′))...)
+# pw(k::Noise{T}, x::AV, x′::AV) where {T} = zeros(T, length(x), length(x′))
 
-# Unary methods.
-ew(k::Noise{T}, x::AV) where {T} = ones(T, length(x))
-pw(k::Noise{T}, x::AV) where {T} = diagm(0=>ones(T, length(x)))
+# # Unary methods.
+# ew(k::Noise{T}, x::AV) where {T} = ones(T, length(x))
+# pw(k::Noise{T}, x::AV) where {T} = diagm(0=>ones(T, length(x)))
 
 
-"""
-    Precomputed{T<:Real} <: Kernel
+# """
+#     Precomputed{T<:Real} <: Kernel
 
-Using the values of a precomputed Gram matrix as a kernel.
+# Using the values of a precomputed Gram matrix as a kernel.
 
-Optionally checks if the Gram matrix is positive definite by setting
-`checkpd=true`
-"""
-struct Precomputed{M<:AbstractMatrix{<:Real}} <: Kernel
-    K::M
-    function Precomputed(K::AbstractMatrix{<:Real}; checkpd=false)
-        checksquare(K)
-        checkpd && @assert isposdef(K) "M is not positive definite"
-        new{typeof(K)}(K)
-    end
-end
+# Optionally checks if the Gram matrix is positive definite by setting
+# `checkpd=true`
+# """
+# struct Precomputed{M<:AbstractMatrix{<:Real}} <: Kernel
+#     K::M
+#     function Precomputed(K::AbstractMatrix{<:Real}; checkpd=false)
+#         checksquare(K)
+#         checkpd && @assert isposdef(K) "M is not positive definite"
+#         new{typeof(K)}(K)
+#     end
+# end
 
-# Binary methods.
-ew(k::Precomputed, x::AV{<:Integer}, x′::AV{<:Integer}) = [k.K[p, q] for (p, q) in zip(x, x′)]
-pw(k::Precomputed, x::AV{<:Integer}, x′::AV{<:Integer}) = k.K[x, x′]
+# # Binary methods.
+# ew(k::Precomputed, x::AV{<:Integer}, x′::AV{<:Integer}) = [k.K[p, q] for (p, q) in zip(x, x′)]
+# pw(k::Precomputed, x::AV{<:Integer}, x′::AV{<:Integer}) = k.K[x, x′]
 
-# Unary methods.
-ew(k::Precomputed, x::AV{<:Integer}) = diag(k.K)[x]
-pw(k::Precomputed, x::AV{<:Integer}) = k.K[x,x]
+# # Unary methods.
+# ew(k::Precomputed, x::AV{<:Integer}) = diag(k.K)[x]
+# pw(k::Precomputed, x::AV{<:Integer}) = k.K[x,x]
 
-precomputed(K::AbstractMatrix) = Precomputed(K)
-export precomputed
+# precomputed(K::AbstractMatrix) = Precomputed(K)
+# export precomputed
 
 
 
-#
-# Composite Kernels
-#
+# #
+# # Composite Kernels
+# #
 
-"""
-    Sum{Tkl<:Kernel, Tkr<:Kernel} <: Kernel
+# """
+#     Sum{Tkl<:Kernel, Tkr<:Kernel} <: Kernel
 
-Represents the sum of two kernels `kl` and `kr` s.t. `k(x, x′) = kl(x, x′) + kr(x, x′)`.
-"""
-struct Sum{Tkl<:Kernel, Tkr<:Kernel} <: Kernel
-    kl::Tkl
-    kr::Tkr
-end
+# Represents the sum of two kernels `kl` and `kr` s.t. `k(x, x′) = kl(x, x′) + kr(x, x′)`.
+# """
+# struct Sum{Tkl<:Kernel, Tkr<:Kernel} <: Kernel
+#     kl::Tkl
+#     kr::Tkr
+# end
 
-+(kl::Kernel, kr::Kernel) = Sum(kl, kr)
+# +(kl::Kernel, kr::Kernel) = Sum(kl, kr)
 
-# Binary methods
-ew(k::Sum, x::AV, x′::AV) = ew(k.kl, x, x′) + ew(k.kr, x, x′)
-pw(k::Sum, x::AV, x′::AV) = pw(k.kl, x, x′) + pw(k.kr, x, x′)
+# # Binary methods
+# ew(k::Sum, x::AV, x′::AV) = ew(k.kl, x, x′) + ew(k.kr, x, x′)
+# pw(k::Sum, x::AV, x′::AV) = pw(k.kl, x, x′) + pw(k.kr, x, x′)
 
-# Unary methods
-ew(k::Sum, x::AV) = ew(k.kl, x) + ew(k.kr, x)
-pw(k::Sum, x::AV) = pw(k.kl, x) + pw(k.kr, x)
+# # Unary methods
+# ew(k::Sum, x::AV) = ew(k.kl, x) + ew(k.kr, x)
+# pw(k::Sum, x::AV) = pw(k.kl, x) + pw(k.kr, x)
 
 
 
-"""
-    Product{Tkl<:Kernel, Tkr<:Kernel} <: Kernel
+# """
+#     Product{Tkl<:Kernel, Tkr<:Kernel} <: Kernel
 
-Represents the product of two kernels `kl` and `kr` s.t. `k(x, x′) = kl(x, x′) kr(x, x′)`.
-"""
-struct Product{Tkl<:Kernel, Tkr<:Kernel} <: Kernel
-    kl::Tkl
-    kr::Tkr
-end
+# Represents the product of two kernels `kl` and `kr` s.t. `k(x, x′) = kl(x, x′) kr(x, x′)`.
+# """
+# struct Product{Tkl<:Kernel, Tkr<:Kernel} <: Kernel
+#     kl::Tkl
+#     kr::Tkr
+# end
 
-*(kl::Kernel, kr::Kernel) = Product(kl, kr)
+# *(kl::Kernel, kr::Kernel) = Product(kl, kr)
 
-# Binary methods
-ew(k::Product, x::AV, x′::AV) = ew(k.kl, x, x′) .* ew(k.kr, x, x′)
-pw(k::Product, x::AV, x′::AV) = pw(k.kl, x, x′) .* pw(k.kr, x, x′)
+# # Binary methods
+# ew(k::Product, x::AV, x′::AV) = ew(k.kl, x, x′) .* ew(k.kr, x, x′)
+# pw(k::Product, x::AV, x′::AV) = pw(k.kl, x, x′) .* pw(k.kr, x, x′)
 
-# Unary methods
-ew(k::Product, x::AV) = ew(k.kl, x) .* ew(k.kr, x)
-pw(k::Product, x::AV) = pw(k.kl, x) .* pw(k.kr, x)
+# # Unary methods
+# ew(k::Product, x::AV) = ew(k.kl, x) .* ew(k.kr, x)
+# pw(k::Product, x::AV) = pw(k.kl, x) .* pw(k.kr, x)
 
 
 
-"""
-    Scaled{Tσ²<:Real, Tk<:Kernel} <: Kernel
+# """
+#     Scaled{Tσ²<:Real, Tk<:Kernel} <: Kernel
 
-Scale the variance of `Kernel` `k` by `σ²` s.t. `(σ² * k)(x, x′) = σ² * k(x, x′)`.
-"""
-struct Scaled{Tσ²<:Real, Tk<:Kernel} <: Kernel
-    σ²::Tσ²
-    k::Tk
-end
+# Scale the variance of `Kernel` `k` by `σ²` s.t. `(σ² * k)(x, x′) = σ² * k(x, x′)`.
+# """
+# struct Scaled{Tσ²<:Real, Tk<:Kernel} <: Kernel
+#     σ²::Tσ²
+#     k::Tk
+# end
 
-*(σ²::Real, k::Kernel) = Scaled(σ², k)
-*(k::Kernel, σ²) = σ² * k
+# *(σ²::Real, k::Kernel) = Scaled(σ², k)
+# *(k::Kernel, σ²) = σ² * k
 
-# Binary methods.
-ew(k::Scaled, x::AV, x′::AV) = k.σ² .* ew(k.k, x, x′)
-pw(k::Scaled, x::AV, x′::AV) = k.σ² .* pw(k.k, x, x′)
+# # Binary methods.
+# ew(k::Scaled, x::AV, x′::AV) = k.σ² .* ew(k.k, x, x′)
+# pw(k::Scaled, x::AV, x′::AV) = k.σ² .* pw(k.k, x, x′)
 
-# Unary methods.
-ew(k::Scaled, x::AV) = k.σ² .* ew(k.k, x)
-pw(k::Scaled, x::AV) = k.σ² .* pw(k.k, x)
+# # Unary methods.
+# ew(k::Scaled, x::AV) = k.σ² .* ew(k.k, x)
+# pw(k::Scaled, x::AV) = k.σ² .* pw(k.k, x)
 
 
 
-"""
-    Stretched{Tk<:Kernel} <: Kernel
+# """
+#     Stretched{Tk<:Kernel} <: Kernel
 
-Apply a length scale to a kernel. Specifically, `k(x, x′) = k(a * x, a * x′)`.
-"""
-struct Stretched{Ta<:Union{Real, AV{<:Real}, AM{<:Real}}, Tk<:Kernel} <: Kernel
-    a::Ta
-    k::Tk
-end
+# Apply a length scale to a kernel. Specifically, `k(x, x′) = k(a * x, a * x′)`.
+# """
+# struct Stretched{Ta<:Union{Real, AV{<:Real}, AM{<:Real}}, Tk<:Kernel} <: Kernel
+#     a::Ta
+#     k::Tk
+# end
 
-stretch(k::Kernel, a::Union{Real, AV{<:Real}, AM{<:Real}}) = Stretched(a, k)
+# stretch(k::Kernel, a::Union{Real, AV{<:Real}, AM{<:Real}}) = Stretched(a, k)
 
-# Binary methods (scalar `a`, scalar-valued input)
-ew(k::Stretched{<:Real}, x::AV{<:Real}, x′::AV{<:Real}) = ew(k.k, k.a .* x, k.a .* x′)
-pw(k::Stretched{<:Real}, x::AV{<:Real}, x′::AV{<:Real}) = pw(k.k, k.a .* x, k.a .* x′)
+# # Binary methods (scalar `a`, scalar-valued input)
+# ew(k::Stretched{<:Real}, x::AV{<:Real}, x′::AV{<:Real}) = ew(k.k, k.a .* x, k.a .* x′)
+# pw(k::Stretched{<:Real}, x::AV{<:Real}, x′::AV{<:Real}) = pw(k.k, k.a .* x, k.a .* x′)
 
-# Unary methods (scalar)
-ew(k::Stretched{<:Real}, x::AV{<:Real}) = ew(k.k, k.a .* x)
-pw(k::Stretched{<:Real}, x::AV{<:Real}) = pw(k.k, k.a .* x)
+# # Unary methods (scalar)
+# ew(k::Stretched{<:Real}, x::AV{<:Real}) = ew(k.k, k.a .* x)
+# pw(k::Stretched{<:Real}, x::AV{<:Real}) = pw(k.k, k.a .* x)
 
-# Binary methods (scalar and vector `a`, vector-valued input)
-function ew(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs, x′::ColVecs)
-    return ew(k.k, ColVecs(k.a .* x.X), ColVecs(k.a .* x′.X))
-end
-function pw(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs, x′::ColVecs)
-    return pw(k.k, ColVecs(k.a .* x.X), ColVecs(k.a .* x′.X))
-end
+# # Binary methods (scalar and vector `a`, vector-valued input)
+# function ew(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs, x′::ColVecs)
+#     return ew(k.k, ColVecs(k.a .* x.X), ColVecs(k.a .* x′.X))
+# end
+# function pw(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs, x′::ColVecs)
+#     return pw(k.k, ColVecs(k.a .* x.X), ColVecs(k.a .* x′.X))
+# end
 
-# Unary methods (scalar and vector `a`, vector-valued input)
-ew(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs) = ew(k.k, ColVecs(k.a .* x.X))
-pw(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs) = pw(k.k, ColVecs(k.a .* x.X))
+# # Unary methods (scalar and vector `a`, vector-valued input)
+# ew(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs) = ew(k.k, ColVecs(k.a .* x.X))
+# pw(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs) = pw(k.k, ColVecs(k.a .* x.X))
 
-# Binary methods (matrix `a`, vector-valued input)
-function ew(k::Stretched{<:AM{<:Real}}, x::ColVecs, x′::ColVecs)
-    return ew(k.k, ColVecs(k.a * x.X), ColVecs(k.a * x′.X))
-end
-function pw(k::Stretched{<:AM{<:Real}}, x::ColVecs, x′::ColVecs)
-    return pw(k.k, ColVecs(k.a * x.X), ColVecs(k.a * x′.X))
-end
+# # Binary methods (matrix `a`, vector-valued input)
+# function ew(k::Stretched{<:AM{<:Real}}, x::ColVecs, x′::ColVecs)
+#     return ew(k.k, ColVecs(k.a * x.X), ColVecs(k.a * x′.X))
+# end
+# function pw(k::Stretched{<:AM{<:Real}}, x::ColVecs, x′::ColVecs)
+#     return pw(k.k, ColVecs(k.a * x.X), ColVecs(k.a * x′.X))
+# end
 
-# Unary methods (scalar and vector `a`, vector-valued input)
-ew(k::Stretched{<:AM{<:Real}}, x::ColVecs) = ew(k.k, ColVecs(k.a * x.X))
-pw(k::Stretched{<:AM{<:Real}}, x::ColVecs) = pw(k.k, ColVecs(k.a * x.X))
+# # Unary methods (scalar and vector `a`, vector-valued input)
+# ew(k::Stretched{<:AM{<:Real}}, x::ColVecs) = ew(k.k, ColVecs(k.a * x.X))
+# pw(k::Stretched{<:AM{<:Real}}, x::ColVecs) = pw(k.k, ColVecs(k.a * x.X))
 
 # Create convenience versions of each of the kernels that accept a length scale.
 for (k, K) in (
     (:eq, :EQ),
-    (:exponential, :Exp),
-    (:matern12, :Matern12),
-    (:matern32, :Matern32),
-    (:matern52, :Matern52),
-    (:linear, :Linear),
-    (:wiener, :Wiener),
-    (:wiener_velocity, :WienerVelocity),
+    # (:exponential, :Exp),
+    # (:matern12, :Matern12),
+    # (:matern32, :Matern32),
+    # (:matern52, :Matern52),
+    # (:linear, :Linear),
+    # (:wiener, :Wiener),
+    # (:wiener_velocity, :WienerVelocity),
 )
     @eval $k() = $K()
     @eval $k(a::Union{Real, AV{<:Real}, AM{<:Real}}) = stretch($k(), a)
     @eval export $k
 end
 
-rq(α) = RQ(α)
-rq(α, l) = stretch(rq(α), l)
-export rq
+# rq(α) = RQ(α)
+# rq(α, l) = stretch(rq(α), l)
+# export rq
 
-cosine(p) = Cosine(p)
-cosine(p, l) = stretch(cosine(p), l)
-export cosine
+# cosine(p) = Cosine(p)
+# cosine(p, l) = stretch(cosine(p), l)
+# export cosine
 
-γ_exponential(γ::Real) = GammaExp(γ)
-γ_exponential(γ::Real, l::Union{Real, AV{<:Real}, AM{<:Real}}) = stretch(GammaExp(γ), l)
-export γ_exponential
+# γ_exponential(γ::Real) = GammaExp(γ)
+# γ_exponential(γ::Real, l::Union{Real, AV{<:Real}, AM{<:Real}}) = stretch(GammaExp(γ), l)
+# export γ_exponential
 
-poly(p::Int, σ²::Real) = Poly(p, σ²)
-poly(p::Int, σ²::Real, l::Union{Real, AV{<:Real}, AM{<:Real}}) = stretch(Poly(p, σ²), l)
-export poly
+# poly(p::Int, σ²::Real) = Poly(p, σ²)
+# poly(p::Int, σ²::Real, l::Union{Real, AV{<:Real}, AM{<:Real}}) = stretch(Poly(p, σ²), l)
+# export poly
 
 
 

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -224,43 +224,43 @@ pw(k::Cosine, x::AV{<:Real}) = cos.(pi .* pw(Euclidean(), x) ./ k.p)
 
 
 
-# """
-#     Linear{T<:Real} <: Kernel
+"""
+    Linear{T<:Real} <: Kernel
 
-# The standardised linear kernel / dot-product kernel.
-# """
-# struct Linear <: Kernel end
+The standardised linear kernel / dot-product kernel.
+"""
+struct Linear <: Kernel end
 
-# # Binary methods
-# ew(k::Linear, x::AV{<:Real}, x′::AV{<:Real}) = x .* x′
-# pw(k::Linear, x::AV{<:Real}, x′::AV{<:Real}) = x .* x′'
-# ew(k::Linear, x::ColVecs, x′::ColVecs) = reshape(sum(x.X .* x′.X; dims=1), :)
-# pw(k::Linear, x::ColVecs, x′::ColVecs) = x.X' * x′.X
+# Binary methods
+ew(k::Linear, x::AV{<:Real}, x′::AV{<:Real}) = x .* x′
+pw(k::Linear, x::AV{<:Real}, x′::AV{<:Real}) = x .* x′'
+ew(k::Linear, x::ColVecs, x′::ColVecs) = reshape(sum(x.X .* x′.X; dims=1), :)
+pw(k::Linear, x::ColVecs, x′::ColVecs) = x.X' * x′.X
 
-# # Unary methods
-# ew(k::Linear, x::AV{<:Real}) = x.^2
-# pw(k::Linear, x::AV{<:Real}) = x .* x'
-# ew(k::Linear, x::ColVecs) = reshape(sum(abs2.(x.X); dims=1), :)
-# pw(k::Linear, x::ColVecs) = x.X' * x.X
+# Unary methods
+ew(k::Linear, x::AV{<:Real}) = x.^2
+pw(k::Linear, x::AV{<:Real}) = x .* x'
+ew(k::Linear, x::ColVecs) = reshape(sum(abs2.(x.X); dims=1), :)
+pw(k::Linear, x::ColVecs) = x.X' * x.X
 
-# """
-#     LinearArd <: Kernel
-# ARD linear kernel (covariance)
-# ```math
-# k(x,x') = xᵀL⁻²x'
-# ```
-# with length scale ``ℓ = (ℓ₁, ℓ₂, …)`` and ``L = diag(ℓ₁, ℓ₂, …)``.
-# """
-# mutable struct LinearArd{T<:Real} <: Kernel
-#     "Length scale"
-#     ℓ::AV{T}
-#     "Priors for kernel parameters"
-#     priors::Array
-# end
+"""
+    LinearArd <: Kernel
+ARD linear kernel (covariance)
+```math
+k(x,x') = xᵀL⁻²x'
+```
+with length scale ``ℓ = (ℓ₁, ℓ₂, …)`` and ``L = diag(ℓ₁, ℓ₂, …)``.
+"""
+mutable struct LinearArd{T<:Real} <: Kernel
+    "Length scale"
+    ℓ::AV{T}
+    "Priors for kernel parameters"
+    priors::Array
+end
 
-# LinearArd(ll::AV{T}) where T = LinearArd{T}(exp.(ll), [])
+LinearArd(ll::AV{T}) where T = LinearArd{T}(exp.(ll), [])
 
-# ew(lin::LinearArd, x::AV, x′::AV) = dot(x./lin.ℓ, x′./lin.ℓ)
+ew(lin::LinearArd, x::AV, x′::AV) = dot(x./lin.ℓ, x′./lin.ℓ)
 
 
 

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -297,78 +297,78 @@ pw(k::Poly{p}, x::AV) where {p} = _poly.(pw(Linear(), x), k.σ², p)
 
 
 
-# """
-#     GammaExp
+"""
+    GammaExp
 
-# The γ-Exponential kernel, 0 < γ ⩽ 2, is given by `k(xl, xr) = exp(-||xl - xr||^γ)`.
-# """
-# struct GammaExp{Tγ<:Real} <: Kernel
-#     γ::Tγ
-# end
+The γ-Exponential kernel, 0 < γ ⩽ 2, is given by `k(xl, xr) = exp(-||xl - xr||^γ)`.
+"""
+struct GammaExp{Tγ<:Real} <: Kernel
+    γ::Tγ
+end
 
-# # Binary methods
-# ew(k::GammaExp, x::AV, x′::AV) = exp.(.-ew(Euclidean(), x, x′).^k.γ)
-# pw(k::GammaExp, x::AV, x′::AV) = exp.(.-pw(Euclidean(), x, x′).^k.γ)
+# Binary methods
+ew(k::GammaExp, x::AV, x′::AV) = exp.(.-ew(Euclidean(), x, x′).^k.γ)
+pw(k::GammaExp, x::AV, x′::AV) = exp.(.-pw(Euclidean(), x, x′).^k.γ)
 
-# # Unary methods
-# ew(k::GammaExp, x::AV) = exp.(.-ew(Euclidean(), x).^k.γ)
-# pw(k::GammaExp, x::AV) = exp.(.-pw(Euclidean(), x).^k.γ)
-
-
-
-# """
-#     Wiener <: Kernel
-
-# The standardised stationary Wiener-process kernel.
-# """
-# struct Wiener <: Kernel end
-
-# _wiener(x::Real, x′::Real) = min(x, x′)
-
-# # Binary methods
-# ew(k::Wiener, x::AV{<:Real}, x′::AV{<:Real}) = _wiener.(x, x′)
-# pw(k::Wiener, x::AV{<:Real}, x′::AV{<:Real}) = _wiener.(x, x′')
-
-# # Unary methods
-# ew(k::Wiener, x::AV{<:Real}) = x
-# pw(k::Wiener, x::AV{<:Real}) = pw(k, x, x)
+# Unary methods
+ew(k::GammaExp, x::AV) = exp.(.-ew(Euclidean(), x).^k.γ)
+pw(k::GammaExp, x::AV) = exp.(.-pw(Euclidean(), x).^k.γ)
 
 
 
-# """
-#     WienerVelocity <: Kernel
+"""
+    Wiener <: Kernel
 
-# The standardised WienerVelocity kernel.
-# """
-# struct WienerVelocity <: Kernel end
+The standardised stationary Wiener-process kernel.
+"""
+struct Wiener <: Kernel end
 
-# _wiener_vel(x::Real, x′::Real) = min(x, x′)^3 / 3 + abs(x - x′) * min(x, x′)^2 / 2
+_wiener(x::Real, x′::Real) = min(x, x′)
 
-# # Binary methods
-# ew(k::WienerVelocity, x::AV{<:Real}, x′::AV{<:Real}) = _wiener_vel.(x, x′)
-# pw(k::WienerVelocity, x::AV{<:Real}, x′::AV{<:Real}) = _wiener_vel.(x, x′')
+# Binary methods
+ew(k::Wiener, x::AV{<:Real}, x′::AV{<:Real}) = _wiener.(x, x′)
+pw(k::Wiener, x::AV{<:Real}, x′::AV{<:Real}) = _wiener.(x, x′')
 
-# # Unary methods
-# ew(k::WienerVelocity, x::AV{<:Real}) = ew(k, x, x)
-# pw(k::WienerVelocity, x::AV{<:Real}) = pw(k, x, x)
+# Unary methods
+ew(k::Wiener, x::AV{<:Real}) = x
+pw(k::Wiener, x::AV{<:Real}) = pw(k, x, x)
 
 
 
-# """
-#     Noise{T<:Real} <: Kernel
+"""
+    WienerVelocity <: Kernel
 
-# The standardised aleatoric white-noise kernel. Isn't really a kernel, but never mind...
-# """
-# struct Noise{T<:Real} <: Kernel end
-# Noise() = Noise{Int}()
+The standardised WienerVelocity kernel.
+"""
+struct WienerVelocity <: Kernel end
 
-# # Binary methods.
-# ew(k::Noise{T}, x::AV, x′::AV) where {T} = zeros(T, broadcast_shape(size(x), size(x′))...)
-# pw(k::Noise{T}, x::AV, x′::AV) where {T} = zeros(T, length(x), length(x′))
+_wiener_vel(x::Real, x′::Real) = min(x, x′)^3 / 3 + abs(x - x′) * min(x, x′)^2 / 2
 
-# # Unary methods.
-# ew(k::Noise{T}, x::AV) where {T} = ones(T, length(x))
-# pw(k::Noise{T}, x::AV) where {T} = diagm(0=>ones(T, length(x)))
+# Binary methods
+ew(k::WienerVelocity, x::AV{<:Real}, x′::AV{<:Real}) = _wiener_vel.(x, x′)
+pw(k::WienerVelocity, x::AV{<:Real}, x′::AV{<:Real}) = _wiener_vel.(x, x′')
+
+# Unary methods
+ew(k::WienerVelocity, x::AV{<:Real}) = ew(k, x, x)
+pw(k::WienerVelocity, x::AV{<:Real}) = pw(k, x, x)
+
+
+
+"""
+    Noise{T<:Real} <: Kernel
+
+The standardised aleatoric white-noise kernel. Isn't really a kernel, but never mind...
+"""
+struct Noise{T<:Real} <: Kernel end
+Noise() = Noise{Int}()
+
+# Binary methods.
+ew(k::Noise{T}, x::AV, x′::AV) where {T} = zeros(T, broadcast_shape(size(x), size(x′))...)
+pw(k::Noise{T}, x::AV, x′::AV) where {T} = zeros(T, length(x), length(x′))
+
+# Unary methods.
+ew(k::Noise{T}, x::AV) where {T} = ones(T, length(x))
+pw(k::Noise{T}, x::AV) where {T} = diagm(0=>ones(T, length(x)))
 
 
 # """
@@ -519,13 +519,13 @@ pw(k::Poly{p}, x::AV) where {p} = _poly.(pw(Linear(), x), k.σ², p)
 # Create convenience versions of each of the kernels that accept a length scale.
 for (k, K) in (
     (:eq, :EQ),
-    # (:exponential, :Exp),
-    # (:matern12, :Matern12),
-    # (:matern32, :Matern32),
-    # (:matern52, :Matern52),
-    # (:linear, :Linear),
-    # (:wiener, :Wiener),
-    # (:wiener_velocity, :WienerVelocity),
+    (:exponential, :Exp),
+    (:matern12, :Matern12),
+    (:matern32, :Matern32),
+    (:matern52, :Matern52),
+    (:linear, :Linear),
+    (:wiener, :Wiener),
+    (:wiener_velocity, :WienerVelocity),
 )
     @eval $k() = $K()
     @eval $k(a::Union{Real, AV{<:Real}, AM{<:Real}}) = stretch($k(), a)

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -123,64 +123,64 @@ pw(::Exp, x::AV) = exp.(.-pw(Euclidean(), x))
 
 
 
-# """
-#     Matern12
+"""
+    Matern12
 
-# Equivalent to the Exponential kernel.
-# """
-# const Matern12 = Exp
-
-
-
-# """
-#     Matern32 <: Kernel
-
-# The Matern kernel with ν = 3 / 2
-# """
-# struct Matern32 <: Kernel end
-
-# function _matern32(d::Real)
-#     d = sqrt(3) * d
-#     return (1 + d) * exp(-d)
-# end
-
-# # Binary methods
-# ew(k::Matern32, x::AV, x′::AV) = _matern32.(ew(Euclidean(), x, x′))
-# pw(k::Matern32, x::AV, x′::AV) = _matern32.(pw(Euclidean(), x, x′))
-
-# # Unary methods
-# ew(k::Matern32, x::AV) = _matern32.(ew(Euclidean(), x))
-# pw(k::Matern32, x::AV) = _matern32.(pw(Euclidean(), x))
+Equivalent to the Exponential kernel.
+"""
+const Matern12 = Exp
 
 
 
-# """
-#     Matern52 <: Kernel
+"""
+    Matern32 <: Kernel
 
-# The Matern kernel with ν = 5 / 2
-# """
-# struct Matern52 <: Kernel end
+The Matern kernel with ν = 3 / 2
+"""
+struct Matern32 <: Kernel end
 
-# function _matern52(d::Real)
-#     λ = sqrt(5) * d
-#     return (1 + λ + λ^2 / 3) * exp(-λ)
-# end
+function _matern32(d::Real)
+    d = sqrt(3) * d
+    return (1 + d) * exp(-d)
+end
 
-# _matern52(d::AbstractArray{<:Real}) = _matern52.(d)
+# Binary methods
+ew(k::Matern32, x::AV, x′::AV) = _matern32.(ew(Euclidean(), x, x′))
+pw(k::Matern32, x::AV, x′::AV) = _matern32.(pw(Euclidean(), x, x′))
 
-# @adjoint function _matern52(d::AbstractArray{<:Real})
-#     λ = sqrt(5) .* d
-#     b = exp.(-λ)
-#     return (1 .+ λ .+ λ.^2 ./ 3) .* b, Δ->(.-Δ .* sqrt(5) .* b .* λ .* (1 .+ λ) ./ 3,)
-# end
+# Unary methods
+ew(k::Matern32, x::AV) = _matern32.(ew(Euclidean(), x))
+pw(k::Matern32, x::AV) = _matern32.(pw(Euclidean(), x))
 
-# # Binary methods
-# ew(k::Matern52, x::AV, x′::AV) = _matern52(ew(Euclidean(), x, x′))
-# pw(k::Matern52, x::AV, x′::AV) = _matern52(pw(Euclidean(), x, x′))
 
-# # Unary methods
-# ew(k::Matern52, x::AV) = _matern52(ew(Euclidean(), x))
-# pw(k::Matern52, x::AV) = _matern52(pw(Euclidean(), x))
+
+"""
+    Matern52 <: Kernel
+
+The Matern kernel with ν = 5 / 2
+"""
+struct Matern52 <: Kernel end
+
+function _matern52(d::Real)
+    λ = sqrt(5) * d
+    return (1 + λ + λ^2 / 3) * exp(-λ)
+end
+
+_matern52(d::AbstractArray{<:Real}) = _matern52.(d)
+
+@adjoint function _matern52(d::AbstractArray{<:Real})
+    λ = sqrt(5) .* d
+    b = exp.(-λ)
+    return (1 .+ λ .+ λ.^2 ./ 3) .* b, Δ->(.-Δ .* sqrt(5) .* b .* λ .* (1 .+ λ) ./ 3,)
+end
+
+# Binary methods
+ew(k::Matern52, x::AV, x′::AV) = _matern52(ew(Euclidean(), x, x′))
+pw(k::Matern52, x::AV, x′::AV) = _matern52(pw(Euclidean(), x, x′))
+
+# Unary methods
+ew(k::Matern52, x::AV) = _matern52(ew(Euclidean(), x))
+pw(k::Matern52, x::AV) = _matern52(pw(Euclidean(), x))
 
 
 

--- a/src/utils/abstract_data_set.jl
+++ b/src/utils/abstract_data_set.jl
@@ -1,0 +1,77 @@
+"""
+This code is partially taken from Stheno.jl
+https://www.github..com/willtebbutt/Stheno.jl
+"""
+
+import Base: size, eachindex, getindex, view, ==, eltype, convert, zero, getproperty
+import Distances: pairwise
+import Zygote: literal_getproperty, accum, @adjoint
+import Zygote
+import BlockArrays: BlockVector 
+export ColVecs
+
+"""
+    ColVecs{T, TX<:AbstractMatrix}
+
+A lightweight box for an `AbstractMatrix` to make it behave like a vector of vectors.
+"""
+struct ColVecs{T, TX<:AbstractMatrix{T}} <: AbstractVector{Vector{T}}
+    X::TX
+    ColVecs(X::TX) where {T, TX<:AbstractMatrix{T}} = new{T, TX}(X)
+end
+
+@adjoint function ColVecs(X::AbstractMatrix)
+    back(Δ::NamedTuple) = (Δ.X,)
+    back(Δ::AbstractMatrix) = (Δ,)
+    function back(Δ::AbstractVector{<:AbstractVector{<:Real}})
+        throw(error("In slow method"))
+    end
+    return ColVecs(X), back
+end
+
+==(D1::ColVecs, D2::ColVecs) = D1.X == D2.X
+size(D::ColVecs) = (size(D.X, 2),)
+getindex(D::ColVecs, n::Int) = D.X[:, n]
+getindex(D::ColVecs, n::CartesianIndex{1}) = getindex(D, n[1])
+getindex(D::ColVecs, n) = ColVecs(D.X[:, n])
+view(D::ColVecs, n::Int) = view(D.X, :, n)
+view(D::ColVecs, n) = ColVecs(view(D.X, :, n))
+eltype(D::ColVecs{T}) where T = Vector{T}
+zero(D::ColVecs) = ColVecs(zero(D.X))
+
+
+
+################################ Fancy block data set type #################################
+
+"""
+    BlockData{T, TV<:AbstractVector{T}, TX<:AbstractVector{TV}} <: AbstractVector{T}
+
+A strictly ordered collection of `AbstractVector`s, representing a ragged array of data.
+"""
+struct BlockData{T, V<:AbstractVector{<:T}} <: AbstractVector{T}
+    X::Vector{V}
+end
+
+BlockData(X::Vector{AbstractVector}) = BlockData{Any, AbstractVector}(X)
+==(D1::BlockData, D2::BlockData) = D1.X == D2.X
+size(D::BlockData) = (sum(length, D.X),)
+
+blocks(X::BlockData) = X.X
+function getindex(D::BlockData, n::Int)
+    b = 1
+    while n > length(D.X[b])
+        n -= length(D.X[b])
+        b += 1
+    end
+    return D.X[b][n]
+end
+function getindex(D::BlockData, n::BlockVector{<:Integer})
+    @assert eachindex(D) == n
+    return D
+end
+view(D::BlockData, b::Int, n) = view(D.X[b], n)
+eltype(D::BlockData{T}) where T = T
+function eachindex(D::BlockData)
+    lengths = map(length, blocks(D))
+    return BlockArray(1:sum(lengths), lengths)
+end

--- a/src/utils/distances.jl
+++ b/src/utils/distances.jl
@@ -1,0 +1,37 @@
+"""
+This code is taken from Stheno.jl
+https://www.github..com/willtebbutt/Stheno.jl
+"""
+
+const dtol = 1e-12 # threshold value for precise recalculation of distances
+
+# Implement some extensions to Euclidean and Squared-Euclidean distances.
+for (d, D) in [(:sqeuclidean, :SqEuclidean), (:euclidean, :Euclidean)]
+    @eval begin
+        function ew(d::$D, x::AV{<:Real}, x′::AV{<:Real})
+            return colwise($D(dtol), reshape(x, 1, :), reshape(x′, 1, :))
+        end
+        function pw(d::$D, x::AV{<:Real}, x′::AV{<:Real})
+            return pw($D(dtol), reshape(x, 1, :), reshape(x′, 1, :); dims=2)
+        end
+
+        ew(::$D, x::AV{T}) where {T<:Real} = zeros(T, length(x))
+        pw(::$D, x::AV{<:Real}) = pairwise($D(dtol), x, x)
+
+        ew(::$D, x::ColVecs{<:Real}, x′::ColVecs{<:Real}) = colwise($D(dtol), x.X, x′.X)
+        pw(::$D, x::ColVecs{<:Real}, x′::ColVecs{<:Real}) = pw($D(dtol), x.X, x′.X; dims=2)
+
+        ew(::$D, x::ColVecs{T}) where {T<:Real} = zeros(T, length(x))
+        pw(::$D, x::ColVecs{<:Real}) = pairwise($D(dtol), x.X; dims=2)
+    end
+end
+
+@adjoint function pairwise(::Euclidean, X::AV{<:Real})
+    D, back = Zygote.pullback(X->pairwise(SqEuclidean(dtol), X), X)
+    D .= sqrt.(D)
+    return D, function(Δ)
+        Δ = Δ ./ (2 .* D)
+        Δ[diagind(Δ)] .= 0
+        return (nothing, first(back(Δ)))
+    end
+end

--- a/src/utils/distances.jl
+++ b/src/utils/distances.jl
@@ -3,8 +3,6 @@ This code is taken from Stheno.jl
 https://www.github..com/willtebbutt/Stheno.jl
 """
 
-const dtol = 1e-12 # threshold value for precise recalculation of distances
-
 # Implement some extensions to Euclidean and Squared-Euclidean distances.
 for (d, D) in [(:sqeuclidean, :SqEuclidean), (:euclidean, :Euclidean)]
     @eval begin

--- a/src/utils/zygote_rules.jl
+++ b/src/utils/zygote_rules.jl
@@ -1,0 +1,87 @@
+using Zygote
+using Zygote: @adjoint, literal_getproperty, @nograd
+import Zygote: accum
+
+import Distances: pairwise, colwise
+const dtol = 1e-12 # threshold value for precise recalculation of distances
+
+@nograd MersenneTwister, propertynames, broadcast_shape
+
+function accum(D::Diagonal{T}, B::AbstractMatrix) where {T}
+    A = Matrix{Union{T, Nothing}}(undef, size(D))
+    A[diagind(A)] .= D.diag
+    return accum(A, B)
+end
+accum(A::AbstractMatrix, D::Diagonal) = accum(D, A)
+accum(A::Diagonal, B::Diagonal) = Diagonal(accum(diag(A), diag(B)))
+
+@adjoint function colwise(s::SqEuclidean, x::AbstractMatrix, y::AbstractMatrix)
+    return colwise(s, x, y), function (Δ::AbstractVector)
+        x̄ = 2 .* Δ' .* (x .- y)
+        return nothing, x̄, -x̄
+    end
+end
+
+@adjoint function pairwise(s::SqEuclidean, X::AbstractMatrix; dims=2)
+    D = pairwise(s, X; dims=dims)
+    return D, function(Δ)
+        d1, d2 = Diagonal(vec(sum(Δ; dims=1))), Diagonal(vec(sum(Δ; dims=2)))
+        return (nothing, X * (2 .* (d1 .+ d2 .- Δ .- Δ')))
+    end
+end
+
+@adjoint function colwise(s::Euclidean, x::AbstractMatrix, y::AbstractMatrix)
+    d = colwise(s, x, y)
+    return d, function (Δ::AbstractVector)
+        x̄ = (Δ ./ d)' .* (x .- y)
+        return nothing, x̄, -x̄
+    end
+end
+
+@adjoint function pairwise(::Euclidean, X::AbstractMatrix, Y::AbstractMatrix; dims=2)
+    @assert dims == 2
+    D, back = Zygote.pullback((X, Y)->pairwise(SqEuclidean(dtol), X, Y; dims=2), X, Y)
+    D .= sqrt.(D)
+    return D, Δ -> (nothing, back(Δ ./ (2 .* D))...)
+end
+
+@adjoint function pairwise(::Euclidean, X::AbstractMatrix; dims=2)
+    @assert dims == 2
+    D, back = Zygote.pullback(X->pairwise(SqEuclidean(dtol), X; dims=2), X)
+    D .= sqrt.(D)
+    return D, function(Δ)
+        Δ = Δ ./ (2 .* D)
+        Δ[diagind(Δ)] .= 0
+        return (nothing, first(back(Δ)))
+    end
+end
+
+@adjoint function literal_getproperty(C::Cholesky, ::Val{:factors})
+    error("@adjoint not implemented for :factors as is unsafe.")
+    return literal_getproperty(C, Val(:factors)), function(Δ)
+        error("@adjoint not implemented for :factors. (I couldn't make it work...)")
+    end
+end
+
+import LinearAlgebra: HermOrSym, diag, Diagonal
+
+diag(S::Symmetric{T, <:Diagonal{T}} where T) = S.data.diag
+Zygote._symmetric_back(Δ::Diagonal) = Δ
+
+# Diagonal matrices are always symmetric...
+cholesky(A::HermOrSym{T, <:Diagonal{T}} where T) = cholesky(Diagonal(diag(A)))
+
+
+
+#
+# Some very specific broadcasting hacks while Zygote has crappy broadcasting.
+#
+
+import Base.Broadcast: broadcasted
+
+@adjoint broadcasted(::typeof(-), x::AbstractArray) = .-x, Δ->(nothing, .-Δ,)
+
+@adjoint function broadcasted(::typeof(exp), x::AbstractArray)
+    y = exp.(x)
+    return y, Δ->(nothing, Δ .* y)
+end

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -1,0 +1,10 @@
+using GPJ, Test, Random
+
+Random.seed!(123)
+
+@testset "kernels" begin
+    @testset "ZeroKernel" begin
+        @test ZeroKernel{Float16}()(randn(3), randn(3)) == zeros(3)
+        @test ZeroKernel{Float16}()(randn(3), randn(3); type=:pairwise) == zeros(3,3)
+    end
+end

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -1,10 +1,254 @@
-using GPJ, Test, Random
+"""
+This code is partially taken from Stheno.jl
+https://www.github..com/willtebbutt/Stheno.jl
+"""
 
-Random.seed!(123)
+using GPJ: ZeroKernel, OneKernel, ConstKernel, pw, Stretched, Scaled
+using GPJ: EQ, Exp, Linear, Noise, PerEQ, Matern32, Matern52, RQ, Cosine, Sum, Product, stretch,
+    Poly, GammaExp, Wiener, WienerVelocity, Precomputed
+using LinearAlgebra
+using TimerOutputs, Test, Random
+const to = TimerOutput()
+macro timedtestset(name, code)
+    return esc(:(@timeit to $name @testset $name $code))
+end
 
-@testset "kernels" begin
-    @testset "ZeroKernel" begin
-        @test ZeroKernel{Float16}()(randn(3), randn(3)) == zeros(3)
-        @test ZeroKernel{Float16}()(randn(3), randn(3); type=:pairwise) == zeros(3,3)
+include("test_util.jl")
+@timedtestset "kernel" begin
+
+    @timedtestset "base kernels" begin
+        rng, N, N′, D = MersenneTwister(123456), 5, 6, 2
+        x0 = collect(range(-2.0, 2.0; length=N)) .+ 1e-3 .* randn(rng, N)
+        x1 = collect(range(-1.7, 2.3; length=N)) .+ 1e-3 .* randn(rng, N)
+        x2 = collect(range(-1.7, 3.3; length=N′)) .+ 1e-3 .* randn(rng, N′)
+        x0_r, x1_r = range(-5.0, step=1, length=N), range(-4.0, step=1, length=N)
+        x2_r, x3_r = range(-5.0, step=2, length=N), range(-3.0, step=1, length=N′)
+        x4_r = range(-2.0, step=2, length=N′)
+
+        X0 = ColVecs(randn(rng, D, N))
+        X1 = ColVecs(randn(rng, D, N))
+        X2 = ColVecs(randn(rng, D, N′))
+
+        ȳ, Ȳ, Ȳ_sq = randn(rng, N), randn(rng, N, N′), randn(rng, N, N)
+
+        @timedtestset "ZeroKernel" begin
+            differentiable_kernel_tests(ZeroKernel(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(ZeroKernel(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+        end
+
+        @timedtestset "OneKernel" begin
+            differentiable_kernel_tests(OneKernel(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(OneKernel(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+        end
+
+        @timedtestset "ConstKernel" begin
+            @test ew(ConstKernel(5), x0) == 5 .* ones(length(x0))
+            differentiable_kernel_tests(ConstKernel(5.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(ConstKernel(5.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+        end
+
+        @timedtestset "EQ" begin
+            differentiable_kernel_tests(EQ(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(EQ(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+        end
+
+        @timedtestset "PerEQ" begin
+            differentiable_kernel_tests(PerEQ(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-6)
+        end
+
+        @timedtestset "Exp" begin
+            differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, x0 .+ 1, x1, x2)
+            differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+        end
+
+        @timedtestset "Matern32" begin
+            differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+        end
+
+        @timedtestset "Matern52" begin
+            differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+        end
+
+        @timedtestset "RQ" begin
+            @timedtestset "α=1.0" begin
+                differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            end
+            @timedtestset "α=1.5" begin
+                differentiable_kernel_tests(RQ(1.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                differentiable_kernel_tests(RQ(1.5), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            end
+            @timedtestset "α=100.0" begin
+                differentiable_kernel_tests(RQ(100.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                differentiable_kernel_tests(RQ(100.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            end
+            @timedtestset "single-input" begin
+                adjoint_test((α, x, x′)->ew(RQ(α), x, x′), ȳ, 1.5, x0, x1)
+                adjoint_test((α, x, x′)->pw(RQ(α), x, x′), Ȳ, 1.5, x0, x2)
+                adjoint_test((α, x)->ew(RQ(α), x), ȳ, 1.5, x0)
+                adjoint_test((α, x)->pw(RQ(α), x), Ȳ_sq, 1.5, x0)
+            end
+            @timedtestset "multi-input" begin
+                adjoint_test((α, x, x′)->ew(RQ(α), x, x′), ȳ, 1.5, X0, X1)
+                adjoint_test((α, x, x′)->pw(RQ(α), x, x′), Ȳ, 1.5, X0, X2)
+                adjoint_test((α, x)->ew(RQ(α), x), ȳ, 1.5, X0)
+                adjoint_test((α, x)->pw(RQ(α), x), Ȳ_sq, 1.5, X0)
+            end
+        end
+
+        @timedtestset "Cosine" begin
+            @timedtestset "p=1.0" begin
+                differentiable_kernel_tests(Cosine(1.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
+            end
+            @timedtestset "p=1.5" begin
+                differentiable_kernel_tests(Cosine(1.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
+            end
+            @timedtestset "p=100.0" begin
+                differentiable_kernel_tests(Cosine(100.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
+            end
+            @timedtestset "single-input" begin
+                adjoint_test((p, x, x′)->ew(Cosine(p), x, x′), ȳ, 1.5, x0, x1)
+                adjoint_test((p, x, x′)->pw(Cosine(p), x, x′), Ȳ, 1.5, x0, x2)
+                adjoint_test((p, x)->ew(Cosine(p), x), ȳ, 1.5, x0)
+                adjoint_test((p, x)->pw(Cosine(p), x), Ȳ_sq, 1.5, x0)
+            end
+        end
+
+        @timedtestset "Linear" begin
+            differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+        end
+
+        @timedtestset "Poly" begin
+            @test pw(Poly(1, 0.0), x0) ≈ pw(Linear(), x0)
+            @testset "Poly{$p}" for p in [1, 2, 3]
+                differentiable_kernel_tests(Poly(p, 0.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                differentiable_kernel_tests(Poly(p, 0.5), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            end
+        end
+
+        @timedtestset "GammaExp" begin
+            @test pw(GammaExp(2.0), x0) ≈ pw(stretch(EQ(), sqrt(2)), x0)
+            @testset "γ=$γ" for γ in [1.0, 1.5, 2.0]
+                differentiable_kernel_tests(GammaExp(γ), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                differentiable_kernel_tests(GammaExp(γ), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            end
+        end
+
+        @timedtestset "Wiener" begin
+            x0 = collect(range(0.1, 2.0; length=N)) .+ 1e-3 .* randn(rng, N)
+            x1 = collect(range(0.1, 2.3; length=N)) .+ 1e-3 .* randn(rng, N)
+            x2 = collect(range(0.1, 3.3; length=N′)) .+ 1e-3 .* randn(rng, N′)
+            kernel_tests(Wiener(), x0, x1, x2)
+        end
+
+        @timedtestset "WienerVelocity" begin
+            x0 = collect(range(0.1, 2.0; length=N)) .+ 1e-3 .* randn(rng, N)
+            x1 = collect(range(0.1, 2.3; length=N)) .+ 1e-3 .* randn(rng, N)
+            x2 = collect(range(0.1, 3.3; length=N′)) .+ 1e-3 .* randn(rng, N′)
+            kernel_tests(WienerVelocity(), x0, x1, x2)
+        end
+
+        @timedtestset "Noise" begin
+            @test ew(Noise(), x0, x0) == zeros(length(x0))
+            @test pw(Noise(), x0, x0) == zeros(length(x0), length(x0))
+            @test ew(Noise(), x0) == ones(length(x0))
+            @test pw(Noise(), x0) == Diagonal(ones(length(x0)))
+        end
+
+        @timedtestset "precomputed" begin
+            rng = MersenneTwister(123456)
+            x = ColVecs(randn(rng, N, N))
+            K = pw(linear(), x)
+            k = precomputed(K)
+            @test pw(k, 1:N) == pw(linear(), x)
+            @test ew(k, 1:N) ≈ ew(linear(), x)
+            kernel_tests(k, 1:N-1, 2:N, 1:N)
+        end
+
+        @timedtestset "Sum" begin
+            differentiable_kernel_tests(Sum(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(Sum(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            @test EQ() + Exp() isa Sum
+        end
+
+        @timedtestset "Product" begin
+            differentiable_kernel_tests(Product(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(Product(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            @test EQ() * Exp() isa Product
+        end
+
+        @timedtestset "Scaled" begin
+            differentiable_kernel_tests(Scaled(0.5, EQ()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(Scaled(0.5, EQ()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            adjoint_test(σ²->pw(Scaled(σ², EQ()), X0), Ȳ_sq, 0.5)
+            @test 0.5 * EQ() isa Scaled
+            @test EQ() * 0.5 isa Scaled
+        end
+
+        @timedtestset "Stretched" begin
+            @timedtestset "Scalar a" begin
+                k = stretch(EQ(), 0.1)
+                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-7, rtol=1e-7)
+                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
+            end
+            @timedtestset "Vector a" begin
+                k = stretch(EQ(), randn(rng, D))
+                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
+            end
+            @timedtestset "Matrix a" begin
+                k = stretch(EQ(), randn(rng, D, D))
+                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
+            end
+            @timedtestset "Convenience Constructors" begin
+                unstretched = [
+                    (eq(), EQ()),
+                    (rq(1.5), RQ(1.5)),
+                    (γ_exponential(2.0), GammaExp(2.0)),
+                    (poly(2, 0.6), Poly(2, 0.6)),
+                ]
+                stretched = [
+                    (eq(0.7), stretch(EQ(), 0.7)),
+                    (rq(1.5, 0.5), stretch(RQ(1.5), 0.5)),
+                    (γ_exponential(2.0, 0.53), stretch(GammaExp(2.0), 0.53)),
+                    (poly(2, 0.6, 0.4), stretch(Poly(2, 0.6), 0.4)),
+                ]
+                @testset "$k_conv" for (k_conv, k) in unstretched
+                    @test pw(k_conv, x0) ≈ pw(k, x0)
+                    differentiable_kernel_tests(k_conv, ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                end
+                @testset "$k_conv" for (k_conv, k) in stretched
+                    @test pw(k_conv, x0) ≈ pw(k, x0)
+                    differentiable_kernel_tests(k_conv, ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                end
+
+                # Wiener kernels aren't differentiable.
+                not_diff_unstretched = [
+                    (wiener(), Wiener()),
+                    (wiener_velocity(), WienerVelocity()),
+                ]
+                not_diff_stretched = [
+                    (wiener(0.67), stretch(Wiener(), 0.67)),
+                    (wiener_velocity(0.65), stretch(WienerVelocity(), 0.65)),
+                ]
+                @testset "$k_conv" for (k_conv, k) in not_diff_unstretched
+                    @test pw(k_conv, x0) ≈ pw(k, x0)
+                    kernel_tests(k_conv, abs.(x0), abs.(x1), abs.(x2))
+                end
+                @testset "$k_conv" for (k_conv, k) in not_diff_stretched
+                    @test pw(k_conv, x0) ≈ pw(k, x0)
+                    kernel_tests(k_conv, abs.(x0), abs.(x1), abs.(x2))
+                end
+            end
+        end
+    end
+
+    @timedtestset "(is)zero" begin
+        @test zero(ZeroKernel()) == ZeroKernel()
+        @test zero(EQ()) == ZeroKernel()
+        @test iszero(ZeroKernel()) == true
+        @test iszero(EQ()) == false
     end
 end

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -5,7 +5,7 @@ https://www.github..com/willtebbutt/Stheno.jl
 
 using GPnet
 using GPnet: ZeroKernel, OneKernel, ConstKernel, pw#, Stretched, Scaled
-using GPnet: EQ, PerEQ, Exp, Matern32, Matern52, RQ, Cosine, Linear#, Noise, Cosine, Sum, Product, stretch,
+using GPnet: EQ, PerEQ, Exp, Matern32, Matern52, RQ, Cosine, Linear, Poly#, Noise, Cosine, Sum, Product, stretch,
     #Poly, GammaExp, Wiener, WienerVelocity, Precomputed
 using LinearAlgebra
 using TimerOutputs, Test, Random
@@ -122,13 +122,13 @@ include("test_util.jl")
             differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-    #     @timedtestset "Poly" begin
-    #         @test pw(Poly(1, 0.0), x0) ≈ pw(Linear(), x0)
-    #         @testset "Poly{$p}" for p in [1, 2, 3]
-    #             differentiable_kernel_tests(Poly(p, 0.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #             differentiable_kernel_tests(Poly(p, 0.5), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-    #         end
-    #     end
+        @timedtestset "Poly" begin
+            @test pw(Poly(1, 0.0), x0) ≈ pw(Linear(), x0)
+            @testset "Poly{$p}" for p in [1, 2, 3]
+                differentiable_kernel_tests(Poly(p, 0.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                differentiable_kernel_tests(Poly(p, 0.5), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            end
+        end
 
     #     @timedtestset "GammaExp" begin
     #         @test pw(GammaExp(2.0), x0) ≈ pw(stretch(EQ(), sqrt(2)), x0)

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -5,7 +5,7 @@ https://www.github..com/willtebbutt/Stheno.jl
 
 using GPnet
 using GPnet: ZeroKernel, OneKernel, ConstKernel, pw#, Stretched, Scaled
-using GPnet: EQ, PerEQ, Exp, Matern32, Matern52#, Linear, Noise, RQ, Cosine, Sum, Product, stretch,
+using GPnet: EQ, PerEQ, Exp, Matern32, Matern52, RQ, Cosine#, Linear, Noise, Cosine, Sum, Product, stretch,
     #Poly, GammaExp, Wiener, WienerVelocity, Precomputed
 using LinearAlgebra
 using TimerOutputs, Test, Random
@@ -72,50 +72,50 @@ include("test_util.jl")
             differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-    #     @timedtestset "RQ" begin
-    #         @timedtestset "α=1.0" begin
-    #             differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #             differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-    #         end
-    #         @timedtestset "α=1.5" begin
-    #             differentiable_kernel_tests(RQ(1.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #             differentiable_kernel_tests(RQ(1.5), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-    #         end
-    #         @timedtestset "α=100.0" begin
-    #             differentiable_kernel_tests(RQ(100.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #             differentiable_kernel_tests(RQ(100.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-    #         end
-    #         @timedtestset "single-input" begin
-    #             adjoint_test((α, x, x′)->ew(RQ(α), x, x′), ȳ, 1.5, x0, x1)
-    #             adjoint_test((α, x, x′)->pw(RQ(α), x, x′), Ȳ, 1.5, x0, x2)
-    #             adjoint_test((α, x)->ew(RQ(α), x), ȳ, 1.5, x0)
-    #             adjoint_test((α, x)->pw(RQ(α), x), Ȳ_sq, 1.5, x0)
-    #         end
-    #         @timedtestset "multi-input" begin
-    #             adjoint_test((α, x, x′)->ew(RQ(α), x, x′), ȳ, 1.5, X0, X1)
-    #             adjoint_test((α, x, x′)->pw(RQ(α), x, x′), Ȳ, 1.5, X0, X2)
-    #             adjoint_test((α, x)->ew(RQ(α), x), ȳ, 1.5, X0)
-    #             adjoint_test((α, x)->pw(RQ(α), x), Ȳ_sq, 1.5, X0)
-    #         end
-    #     end
+        @timedtestset "RQ" begin
+            @timedtestset "α=1.0" begin
+                differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            end
+            @timedtestset "α=1.5" begin
+                differentiable_kernel_tests(RQ(1.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                differentiable_kernel_tests(RQ(1.5), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            end
+            @timedtestset "α=100.0" begin
+                differentiable_kernel_tests(RQ(100.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                differentiable_kernel_tests(RQ(100.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            end
+            @timedtestset "single-input" begin
+                adjoint_test((α, x, x′)->ew(RQ(α), x, x′), ȳ, 1.5, x0, x1)
+                adjoint_test((α, x, x′)->pw(RQ(α), x, x′), Ȳ, 1.5, x0, x2)
+                adjoint_test((α, x)->ew(RQ(α), x), ȳ, 1.5, x0)
+                adjoint_test((α, x)->pw(RQ(α), x), Ȳ_sq, 1.5, x0)
+            end
+            @timedtestset "multi-input" begin
+                adjoint_test((α, x, x′)->ew(RQ(α), x, x′), ȳ, 1.5, X0, X1)
+                adjoint_test((α, x, x′)->pw(RQ(α), x, x′), Ȳ, 1.5, X0, X2)
+                adjoint_test((α, x)->ew(RQ(α), x), ȳ, 1.5, X0)
+                adjoint_test((α, x)->pw(RQ(α), x), Ȳ_sq, 1.5, X0)
+            end
+        end
 
-    #     @timedtestset "Cosine" begin
-    #         @timedtestset "p=1.0" begin
-    #             differentiable_kernel_tests(Cosine(1.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
-    #         end
-    #         @timedtestset "p=1.5" begin
-    #             differentiable_kernel_tests(Cosine(1.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
-    #         end
-    #         @timedtestset "p=100.0" begin
-    #             differentiable_kernel_tests(Cosine(100.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
-    #         end
-    #         @timedtestset "single-input" begin
-    #             adjoint_test((p, x, x′)->ew(Cosine(p), x, x′), ȳ, 1.5, x0, x1)
-    #             adjoint_test((p, x, x′)->pw(Cosine(p), x, x′), Ȳ, 1.5, x0, x2)
-    #             adjoint_test((p, x)->ew(Cosine(p), x), ȳ, 1.5, x0)
-    #             adjoint_test((p, x)->pw(Cosine(p), x), Ȳ_sq, 1.5, x0)
-    #         end
-    #     end
+        @timedtestset "Cosine" begin
+            @timedtestset "p=1.0" begin
+                differentiable_kernel_tests(Cosine(1.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
+            end
+            @timedtestset "p=1.5" begin
+                differentiable_kernel_tests(Cosine(1.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
+            end
+            @timedtestset "p=100.0" begin
+                differentiable_kernel_tests(Cosine(100.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
+            end
+            @timedtestset "single-input" begin
+                adjoint_test((p, x, x′)->ew(Cosine(p), x, x′), ȳ, 1.5, x0, x1)
+                adjoint_test((p, x, x′)->pw(Cosine(p), x, x′), Ȳ, 1.5, x0, x2)
+                adjoint_test((p, x)->ew(Cosine(p), x), ȳ, 1.5, x0)
+                adjoint_test((p, x)->pw(Cosine(p), x), Ȳ_sq, 1.5, x0)
+            end
+        end
 
     #     @timedtestset "Linear" begin
     #         differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -5,7 +5,7 @@ https://www.github..com/willtebbutt/Stheno.jl
 
 using GPnet
 using GPnet: ZeroKernel, OneKernel, ConstKernel, pw#, Stretched, Scaled
-using GPnet: EQ, PerEQ, Exp, Matern32, Matern52, RQ, Cosine#, Linear, Noise, Cosine, Sum, Product, stretch,
+using GPnet: EQ, PerEQ, Exp, Matern32, Matern52, RQ, Cosine, Linear#, Noise, Cosine, Sum, Product, stretch,
     #Poly, GammaExp, Wiener, WienerVelocity, Precomputed
 using LinearAlgebra
 using TimerOutputs, Test, Random
@@ -117,10 +117,10 @@ include("test_util.jl")
             end
         end
 
-    #     @timedtestset "Linear" begin
-    #         differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #         differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-    #     end
+        @timedtestset "Linear" begin
+            differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+        end
 
     #     @timedtestset "Poly" begin
     #         @test pw(Poly(1, 0.0), x0) ≈ pw(Linear(), x0)

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -3,9 +3,9 @@ This code is partially taken from Stheno.jl
 https://www.github..com/willtebbutt/Stheno.jl
 """
 
-using GPnet: ZeroKernel, OneKernel, ConstKernel, pw, Stretched, Scaled
-using GPnet: EQ, Exp, Linear, Noise, PerEQ, Matern32, Matern52, RQ, Cosine, Sum, Product, stretch,
-    Poly, GammaExp, Wiener, WienerVelocity, Precomputed
+using GPnet: ZeroKernel, OneKernel, ConstKernel, pw#, Stretched, Scaled
+using GPnet: EQ#, Exp, Linear, Noise, PerEQ, Matern32, Matern52, RQ, Cosine, Sum, Product, stretch,
+    #Poly, GammaExp, Wiener, WienerVelocity, Precomputed
 using LinearAlgebra
 using TimerOutputs, Test, Random
 const to = TimerOutput()
@@ -52,197 +52,197 @@ include("test_util.jl")
             differentiable_kernel_tests(EQ(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-        @timedtestset "PerEQ" begin
-            differentiable_kernel_tests(PerEQ(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-6)
-        end
+    #     @timedtestset "PerEQ" begin
+    #         differentiable_kernel_tests(PerEQ(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-6)
+    #     end
 
-        @timedtestset "Exp" begin
-            differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, x0 .+ 1, x1, x2)
-            differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-        end
+    #     @timedtestset "Exp" begin
+    #         differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, x0 .+ 1, x1, x2)
+    #         differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+    #     end
 
-        @timedtestset "Matern32" begin
-            differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-            differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-        end
+    #     @timedtestset "Matern32" begin
+    #         differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #         differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+    #     end
 
-        @timedtestset "Matern52" begin
-            differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-            differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-        end
+    #     @timedtestset "Matern52" begin
+    #         differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #         differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+    #     end
 
-        @timedtestset "RQ" begin
-            @timedtestset "α=1.0" begin
-                differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-                differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-            end
-            @timedtestset "α=1.5" begin
-                differentiable_kernel_tests(RQ(1.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-                differentiable_kernel_tests(RQ(1.5), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-            end
-            @timedtestset "α=100.0" begin
-                differentiable_kernel_tests(RQ(100.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-                differentiable_kernel_tests(RQ(100.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-            end
-            @timedtestset "single-input" begin
-                adjoint_test((α, x, x′)->ew(RQ(α), x, x′), ȳ, 1.5, x0, x1)
-                adjoint_test((α, x, x′)->pw(RQ(α), x, x′), Ȳ, 1.5, x0, x2)
-                adjoint_test((α, x)->ew(RQ(α), x), ȳ, 1.5, x0)
-                adjoint_test((α, x)->pw(RQ(α), x), Ȳ_sq, 1.5, x0)
-            end
-            @timedtestset "multi-input" begin
-                adjoint_test((α, x, x′)->ew(RQ(α), x, x′), ȳ, 1.5, X0, X1)
-                adjoint_test((α, x, x′)->pw(RQ(α), x, x′), Ȳ, 1.5, X0, X2)
-                adjoint_test((α, x)->ew(RQ(α), x), ȳ, 1.5, X0)
-                adjoint_test((α, x)->pw(RQ(α), x), Ȳ_sq, 1.5, X0)
-            end
-        end
+    #     @timedtestset "RQ" begin
+    #         @timedtestset "α=1.0" begin
+    #             differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #             differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+    #         end
+    #         @timedtestset "α=1.5" begin
+    #             differentiable_kernel_tests(RQ(1.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #             differentiable_kernel_tests(RQ(1.5), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+    #         end
+    #         @timedtestset "α=100.0" begin
+    #             differentiable_kernel_tests(RQ(100.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #             differentiable_kernel_tests(RQ(100.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+    #         end
+    #         @timedtestset "single-input" begin
+    #             adjoint_test((α, x, x′)->ew(RQ(α), x, x′), ȳ, 1.5, x0, x1)
+    #             adjoint_test((α, x, x′)->pw(RQ(α), x, x′), Ȳ, 1.5, x0, x2)
+    #             adjoint_test((α, x)->ew(RQ(α), x), ȳ, 1.5, x0)
+    #             adjoint_test((α, x)->pw(RQ(α), x), Ȳ_sq, 1.5, x0)
+    #         end
+    #         @timedtestset "multi-input" begin
+    #             adjoint_test((α, x, x′)->ew(RQ(α), x, x′), ȳ, 1.5, X0, X1)
+    #             adjoint_test((α, x, x′)->pw(RQ(α), x, x′), Ȳ, 1.5, X0, X2)
+    #             adjoint_test((α, x)->ew(RQ(α), x), ȳ, 1.5, X0)
+    #             adjoint_test((α, x)->pw(RQ(α), x), Ȳ_sq, 1.5, X0)
+    #         end
+    #     end
 
-        @timedtestset "Cosine" begin
-            @timedtestset "p=1.0" begin
-                differentiable_kernel_tests(Cosine(1.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
-            end
-            @timedtestset "p=1.5" begin
-                differentiable_kernel_tests(Cosine(1.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
-            end
-            @timedtestset "p=100.0" begin
-                differentiable_kernel_tests(Cosine(100.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
-            end
-            @timedtestset "single-input" begin
-                adjoint_test((p, x, x′)->ew(Cosine(p), x, x′), ȳ, 1.5, x0, x1)
-                adjoint_test((p, x, x′)->pw(Cosine(p), x, x′), Ȳ, 1.5, x0, x2)
-                adjoint_test((p, x)->ew(Cosine(p), x), ȳ, 1.5, x0)
-                adjoint_test((p, x)->pw(Cosine(p), x), Ȳ_sq, 1.5, x0)
-            end
-        end
+    #     @timedtestset "Cosine" begin
+    #         @timedtestset "p=1.0" begin
+    #             differentiable_kernel_tests(Cosine(1.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
+    #         end
+    #         @timedtestset "p=1.5" begin
+    #             differentiable_kernel_tests(Cosine(1.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
+    #         end
+    #         @timedtestset "p=100.0" begin
+    #             differentiable_kernel_tests(Cosine(100.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-8)        
+    #         end
+    #         @timedtestset "single-input" begin
+    #             adjoint_test((p, x, x′)->ew(Cosine(p), x, x′), ȳ, 1.5, x0, x1)
+    #             adjoint_test((p, x, x′)->pw(Cosine(p), x, x′), Ȳ, 1.5, x0, x2)
+    #             adjoint_test((p, x)->ew(Cosine(p), x), ȳ, 1.5, x0)
+    #             adjoint_test((p, x)->pw(Cosine(p), x), Ȳ_sq, 1.5, x0)
+    #         end
+    #     end
 
-        @timedtestset "Linear" begin
-            differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-            differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-        end
+    #     @timedtestset "Linear" begin
+    #         differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #         differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+    #     end
 
-        @timedtestset "Poly" begin
-            @test pw(Poly(1, 0.0), x0) ≈ pw(Linear(), x0)
-            @testset "Poly{$p}" for p in [1, 2, 3]
-                differentiable_kernel_tests(Poly(p, 0.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-                differentiable_kernel_tests(Poly(p, 0.5), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-            end
-        end
+    #     @timedtestset "Poly" begin
+    #         @test pw(Poly(1, 0.0), x0) ≈ pw(Linear(), x0)
+    #         @testset "Poly{$p}" for p in [1, 2, 3]
+    #             differentiable_kernel_tests(Poly(p, 0.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #             differentiable_kernel_tests(Poly(p, 0.5), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+    #         end
+    #     end
 
-        @timedtestset "GammaExp" begin
-            @test pw(GammaExp(2.0), x0) ≈ pw(stretch(EQ(), sqrt(2)), x0)
-            @testset "γ=$γ" for γ in [1.0, 1.5, 2.0]
-                differentiable_kernel_tests(GammaExp(γ), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-                differentiable_kernel_tests(GammaExp(γ), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-            end
-        end
+    #     @timedtestset "GammaExp" begin
+    #         @test pw(GammaExp(2.0), x0) ≈ pw(stretch(EQ(), sqrt(2)), x0)
+    #         @testset "γ=$γ" for γ in [1.0, 1.5, 2.0]
+    #             differentiable_kernel_tests(GammaExp(γ), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #             differentiable_kernel_tests(GammaExp(γ), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+    #         end
+    #     end
 
-        @timedtestset "Wiener" begin
-            x0 = collect(range(0.1, 2.0; length=N)) .+ 1e-3 .* randn(rng, N)
-            x1 = collect(range(0.1, 2.3; length=N)) .+ 1e-3 .* randn(rng, N)
-            x2 = collect(range(0.1, 3.3; length=N′)) .+ 1e-3 .* randn(rng, N′)
-            kernel_tests(Wiener(), x0, x1, x2)
-        end
+    #     @timedtestset "Wiener" begin
+    #         x0 = collect(range(0.1, 2.0; length=N)) .+ 1e-3 .* randn(rng, N)
+    #         x1 = collect(range(0.1, 2.3; length=N)) .+ 1e-3 .* randn(rng, N)
+    #         x2 = collect(range(0.1, 3.3; length=N′)) .+ 1e-3 .* randn(rng, N′)
+    #         kernel_tests(Wiener(), x0, x1, x2)
+    #     end
 
-        @timedtestset "WienerVelocity" begin
-            x0 = collect(range(0.1, 2.0; length=N)) .+ 1e-3 .* randn(rng, N)
-            x1 = collect(range(0.1, 2.3; length=N)) .+ 1e-3 .* randn(rng, N)
-            x2 = collect(range(0.1, 3.3; length=N′)) .+ 1e-3 .* randn(rng, N′)
-            kernel_tests(WienerVelocity(), x0, x1, x2)
-        end
+    #     @timedtestset "WienerVelocity" begin
+    #         x0 = collect(range(0.1, 2.0; length=N)) .+ 1e-3 .* randn(rng, N)
+    #         x1 = collect(range(0.1, 2.3; length=N)) .+ 1e-3 .* randn(rng, N)
+    #         x2 = collect(range(0.1, 3.3; length=N′)) .+ 1e-3 .* randn(rng, N′)
+    #         kernel_tests(WienerVelocity(), x0, x1, x2)
+    #     end
 
-        @timedtestset "Noise" begin
-            @test ew(Noise(), x0, x0) == zeros(length(x0))
-            @test pw(Noise(), x0, x0) == zeros(length(x0), length(x0))
-            @test ew(Noise(), x0) == ones(length(x0))
-            @test pw(Noise(), x0) == Diagonal(ones(length(x0)))
-        end
+    #     @timedtestset "Noise" begin
+    #         @test ew(Noise(), x0, x0) == zeros(length(x0))
+    #         @test pw(Noise(), x0, x0) == zeros(length(x0), length(x0))
+    #         @test ew(Noise(), x0) == ones(length(x0))
+    #         @test pw(Noise(), x0) == Diagonal(ones(length(x0)))
+    #     end
 
-        @timedtestset "precomputed" begin
-            rng = MersenneTwister(123456)
-            x = ColVecs(randn(rng, N, N))
-            K = pw(linear(), x)
-            k = precomputed(K)
-            @test pw(k, 1:N) == pw(linear(), x)
-            @test ew(k, 1:N) ≈ ew(linear(), x)
-            kernel_tests(k, 1:N-1, 2:N, 1:N)
-        end
+    #     @timedtestset "precomputed" begin
+    #         rng = MersenneTwister(123456)
+    #         x = ColVecs(randn(rng, N, N))
+    #         K = pw(linear(), x)
+    #         k = precomputed(K)
+    #         @test pw(k, 1:N) == pw(linear(), x)
+    #         @test ew(k, 1:N) ≈ ew(linear(), x)
+    #         kernel_tests(k, 1:N-1, 2:N, 1:N)
+    #     end
 
-        @timedtestset "Sum" begin
-            differentiable_kernel_tests(Sum(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-            differentiable_kernel_tests(Sum(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-            @test EQ() + Exp() isa Sum
-        end
+    #     @timedtestset "Sum" begin
+    #         differentiable_kernel_tests(Sum(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #         differentiable_kernel_tests(Sum(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+    #         @test EQ() + Exp() isa Sum
+    #     end
 
-        @timedtestset "Product" begin
-            differentiable_kernel_tests(Product(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-            differentiable_kernel_tests(Product(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-            @test EQ() * Exp() isa Product
-        end
+    #     @timedtestset "Product" begin
+    #         differentiable_kernel_tests(Product(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #         differentiable_kernel_tests(Product(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+    #         @test EQ() * Exp() isa Product
+    #     end
 
-        @timedtestset "Scaled" begin
-            differentiable_kernel_tests(Scaled(0.5, EQ()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-            differentiable_kernel_tests(Scaled(0.5, EQ()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-            adjoint_test(σ²->pw(Scaled(σ², EQ()), X0), Ȳ_sq, 0.5)
-            @test 0.5 * EQ() isa Scaled
-            @test EQ() * 0.5 isa Scaled
-        end
+    #     @timedtestset "Scaled" begin
+    #         differentiable_kernel_tests(Scaled(0.5, EQ()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #         differentiable_kernel_tests(Scaled(0.5, EQ()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+    #         adjoint_test(σ²->pw(Scaled(σ², EQ()), X0), Ȳ_sq, 0.5)
+    #         @test 0.5 * EQ() isa Scaled
+    #         @test EQ() * 0.5 isa Scaled
+    #     end
 
-        @timedtestset "Stretched" begin
-            @timedtestset "Scalar a" begin
-                k = stretch(EQ(), 0.1)
-                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-7, rtol=1e-7)
-                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
-            end
-            @timedtestset "Vector a" begin
-                k = stretch(EQ(), randn(rng, D))
-                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
-            end
-            @timedtestset "Matrix a" begin
-                k = stretch(EQ(), randn(rng, D, D))
-                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
-            end
-            @timedtestset "Convenience Constructors" begin
-                unstretched = [
-                    (eq(), EQ()),
-                    (rq(1.5), RQ(1.5)),
-                    (γ_exponential(2.0), GammaExp(2.0)),
-                    (poly(2, 0.6), Poly(2, 0.6)),
-                ]
-                stretched = [
-                    (eq(0.7), stretch(EQ(), 0.7)),
-                    (rq(1.5, 0.5), stretch(RQ(1.5), 0.5)),
-                    (γ_exponential(2.0, 0.53), stretch(GammaExp(2.0), 0.53)),
-                    (poly(2, 0.6, 0.4), stretch(Poly(2, 0.6), 0.4)),
-                ]
-                @testset "$k_conv" for (k_conv, k) in unstretched
-                    @test pw(k_conv, x0) ≈ pw(k, x0)
-                    differentiable_kernel_tests(k_conv, ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-                end
-                @testset "$k_conv" for (k_conv, k) in stretched
-                    @test pw(k_conv, x0) ≈ pw(k, x0)
-                    differentiable_kernel_tests(k_conv, ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-                end
+    #     @timedtestset "Stretched" begin
+    #         @timedtestset "Scalar a" begin
+    #             k = stretch(EQ(), 0.1)
+    #             differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-7, rtol=1e-7)
+    #             differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
+    #         end
+    #         @timedtestset "Vector a" begin
+    #             k = stretch(EQ(), randn(rng, D))
+    #             differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
+    #         end
+    #         @timedtestset "Matrix a" begin
+    #             k = stretch(EQ(), randn(rng, D, D))
+    #             differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
+    #         end
+    #         @timedtestset "Convenience Constructors" begin
+    #             unstretched = [
+    #                 (eq(), EQ()),
+    #                 (rq(1.5), RQ(1.5)),
+    #                 (γ_exponential(2.0), GammaExp(2.0)),
+    #                 (poly(2, 0.6), Poly(2, 0.6)),
+    #             ]
+    #             stretched = [
+    #                 (eq(0.7), stretch(EQ(), 0.7)),
+    #                 (rq(1.5, 0.5), stretch(RQ(1.5), 0.5)),
+    #                 (γ_exponential(2.0, 0.53), stretch(GammaExp(2.0), 0.53)),
+    #                 (poly(2, 0.6, 0.4), stretch(Poly(2, 0.6), 0.4)),
+    #             ]
+    #             @testset "$k_conv" for (k_conv, k) in unstretched
+    #                 @test pw(k_conv, x0) ≈ pw(k, x0)
+    #                 differentiable_kernel_tests(k_conv, ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #             end
+    #             @testset "$k_conv" for (k_conv, k) in stretched
+    #                 @test pw(k_conv, x0) ≈ pw(k, x0)
+    #                 differentiable_kernel_tests(k_conv, ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+    #             end
 
-                # Wiener kernels aren't differentiable.
-                not_diff_unstretched = [
-                    (wiener(), Wiener()),
-                    (wiener_velocity(), WienerVelocity()),
-                ]
-                not_diff_stretched = [
-                    (wiener(0.67), stretch(Wiener(), 0.67)),
-                    (wiener_velocity(0.65), stretch(WienerVelocity(), 0.65)),
-                ]
-                @testset "$k_conv" for (k_conv, k) in not_diff_unstretched
-                    @test pw(k_conv, x0) ≈ pw(k, x0)
-                    kernel_tests(k_conv, abs.(x0), abs.(x1), abs.(x2))
-                end
-                @testset "$k_conv" for (k_conv, k) in not_diff_stretched
-                    @test pw(k_conv, x0) ≈ pw(k, x0)
-                    kernel_tests(k_conv, abs.(x0), abs.(x1), abs.(x2))
-                end
-            end
-        end
+    #             # Wiener kernels aren't differentiable.
+    #             not_diff_unstretched = [
+    #                 (wiener(), Wiener()),
+    #                 (wiener_velocity(), WienerVelocity()),
+    #             ]
+    #             not_diff_stretched = [
+    #                 (wiener(0.67), stretch(Wiener(), 0.67)),
+    #                 (wiener_velocity(0.65), stretch(WienerVelocity(), 0.65)),
+    #             ]
+    #             @testset "$k_conv" for (k_conv, k) in not_diff_unstretched
+    #                 @test pw(k_conv, x0) ≈ pw(k, x0)
+    #                 kernel_tests(k_conv, abs.(x0), abs.(x1), abs.(x2))
+    #             end
+    #             @testset "$k_conv" for (k_conv, k) in not_diff_stretched
+    #                 @test pw(k_conv, x0) ≈ pw(k, x0)
+    #                 kernel_tests(k_conv, abs.(x0), abs.(x1), abs.(x2))
+    #             end
+    #         end
+    #     end
     end
 
     @timedtestset "(is)zero" begin

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -5,7 +5,7 @@ https://www.github..com/willtebbutt/Stheno.jl
 
 using GPnet
 using GPnet: ZeroKernel, OneKernel, ConstKernel, pw#, Stretched, Scaled
-using GPnet: EQ, PerEQ, Exp#, Linear, Noise, Matern32, Matern52, RQ, Cosine, Sum, Product, stretch,
+using GPnet: EQ, PerEQ, Exp, Matern32, Matern52#, Linear, Noise, RQ, Cosine, Sum, Product, stretch,
     #Poly, GammaExp, Wiener, WienerVelocity, Precomputed
 using LinearAlgebra
 using TimerOutputs, Test, Random
@@ -62,15 +62,15 @@ include("test_util.jl")
             differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-    #     @timedtestset "Matern32" begin
-    #         differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #         differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-    #     end
+        @timedtestset "Matern32" begin
+            differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+        end
 
-    #     @timedtestset "Matern52" begin
-    #         differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #         differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-    #     end
+        @timedtestset "Matern52" begin
+            differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+        end
 
     #     @timedtestset "RQ" begin
     #         @timedtestset "α=1.0" begin

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -3,8 +3,8 @@ This code is partially taken from Stheno.jl
 https://www.github..com/willtebbutt/Stheno.jl
 """
 
-using GPJ: ZeroKernel, OneKernel, ConstKernel, pw, Stretched, Scaled
-using GPJ: EQ, Exp, Linear, Noise, PerEQ, Matern32, Matern52, RQ, Cosine, Sum, Product, stretch,
+using GPnet: ZeroKernel, OneKernel, ConstKernel, pw, Stretched, Scaled
+using GPnet: EQ, Exp, Linear, Noise, PerEQ, Matern32, Matern52, RQ, Cosine, Sum, Product, stretch,
     Poly, GammaExp, Wiener, WienerVelocity, Precomputed
 using LinearAlgebra
 using TimerOutputs, Test, Random

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -3,8 +3,9 @@ This code is partially taken from Stheno.jl
 https://www.github..com/willtebbutt/Stheno.jl
 """
 
+using GPnet
 using GPnet: ZeroKernel, OneKernel, ConstKernel, pw#, Stretched, Scaled
-using GPnet: EQ#, Exp, Linear, Noise, PerEQ, Matern32, Matern52, RQ, Cosine, Sum, Product, stretch,
+using GPnet: EQ, PerEQ, Exp#, Linear, Noise, Matern32, Matern52, RQ, Cosine, Sum, Product, stretch,
     #Poly, GammaExp, Wiener, WienerVelocity, Precomputed
 using LinearAlgebra
 using TimerOutputs, Test, Random
@@ -52,14 +53,14 @@ include("test_util.jl")
             differentiable_kernel_tests(EQ(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-    #     @timedtestset "PerEQ" begin
-    #         differentiable_kernel_tests(PerEQ(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-6)
-    #     end
+        @timedtestset "PerEQ" begin
+            differentiable_kernel_tests(PerEQ(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-6)
+        end
 
-    #     @timedtestset "Exp" begin
-    #         differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, x0 .+ 1, x1, x2)
-    #         differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-    #     end
+        @timedtestset "Exp" begin
+            differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, x0 .+ 1, x1, x2)
+            differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+        end
 
     #     @timedtestset "Matern32" begin
     #         differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -4,9 +4,9 @@ https://www.github..com/willtebbutt/Stheno.jl
 """
 
 using GPnet
-using GPnet: ZeroKernel, OneKernel, ConstKernel, pw#, Stretched, Scaled
-using GPnet: EQ, PerEQ, Exp, Matern32, Matern52, RQ, Cosine, Linear, Poly, GammaExp, Wiener, WienerVelocity, Noise#, Sum, Product, stretch,
-    #Poly, Precomputed
+using GPnet: ZeroKernel, OneKernel, ConstKernel, pw, EQ, PerEQ, Exp, Matern32,
+    Matern52, RQ, Cosine, Linear, Poly, GammaExp, Wiener, WienerVelocity,
+    Noise, Precomputed, Sum, Product, Scaled, Stretched, stretch
 using LinearAlgebra
 using TimerOutputs, Test, Random
 const to = TimerOutput()
@@ -131,7 +131,7 @@ include("test_util.jl")
         end
 
         @timedtestset "GammaExp" begin
-            @test_broken pw(GammaExp(2.0), x0) ≈ pw(stretch(EQ(), sqrt(2)), x0)
+            @test pw(GammaExp(2.0), x0) ≈ pw(stretch(EQ(), sqrt(2)), x0)
             @testset "γ=$γ" for γ in [1.0, 1.5, 2.0]
                 differentiable_kernel_tests(GammaExp(γ), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
                 differentiable_kernel_tests(GammaExp(γ), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
@@ -159,91 +159,91 @@ include("test_util.jl")
             @test pw(Noise(), x0) == Diagonal(ones(length(x0)))
         end
 
-    #     @timedtestset "precomputed" begin
-    #         rng = MersenneTwister(123456)
-    #         x = ColVecs(randn(rng, N, N))
-    #         K = pw(linear(), x)
-    #         k = precomputed(K)
-    #         @test pw(k, 1:N) == pw(linear(), x)
-    #         @test ew(k, 1:N) ≈ ew(linear(), x)
-    #         kernel_tests(k, 1:N-1, 2:N, 1:N)
-    #     end
+        @timedtestset "precomputed" begin
+            rng = MersenneTwister(123456)
+            x = ColVecs(randn(rng, N, N))
+            K = pw(linear(), x)
+            k = precomputed(K)
+            @test pw(k, 1:N) == pw(linear(), x)
+            @test ew(k, 1:N) ≈ ew(linear(), x)
+            kernel_tests(k, 1:N-1, 2:N, 1:N)
+        end
 
-    #     @timedtestset "Sum" begin
-    #         differentiable_kernel_tests(Sum(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #         differentiable_kernel_tests(Sum(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-    #         @test EQ() + Exp() isa Sum
-    #     end
+        @timedtestset "Sum" begin
+            differentiable_kernel_tests(Sum(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(Sum(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            @test EQ() + Exp() isa Sum
+        end
 
-    #     @timedtestset "Product" begin
-    #         differentiable_kernel_tests(Product(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #         differentiable_kernel_tests(Product(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-    #         @test EQ() * Exp() isa Product
-    #     end
+        @timedtestset "Product" begin
+            differentiable_kernel_tests(Product(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(Product(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            @test EQ() * Exp() isa Product
+        end
 
-    #     @timedtestset "Scaled" begin
-    #         differentiable_kernel_tests(Scaled(0.5, EQ()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #         differentiable_kernel_tests(Scaled(0.5, EQ()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-    #         adjoint_test(σ²->pw(Scaled(σ², EQ()), X0), Ȳ_sq, 0.5)
-    #         @test 0.5 * EQ() isa Scaled
-    #         @test EQ() * 0.5 isa Scaled
-    #     end
+        @timedtestset "Scaled" begin
+            differentiable_kernel_tests(Scaled(0.5, EQ()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+            differentiable_kernel_tests(Scaled(0.5, EQ()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            adjoint_test(σ²->pw(Scaled(σ², EQ()), X0), Ȳ_sq, 0.5)
+            @test 0.5 * EQ() isa Scaled
+            @test EQ() * 0.5 isa Scaled
+        end
 
-    #     @timedtestset "Stretched" begin
-    #         @timedtestset "Scalar a" begin
-    #             k = stretch(EQ(), 0.1)
-    #             differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-7, rtol=1e-7)
-    #             differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
-    #         end
-    #         @timedtestset "Vector a" begin
-    #             k = stretch(EQ(), randn(rng, D))
-    #             differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
-    #         end
-    #         @timedtestset "Matrix a" begin
-    #             k = stretch(EQ(), randn(rng, D, D))
-    #             differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
-    #         end
-    #         @timedtestset "Convenience Constructors" begin
-    #             unstretched = [
-    #                 (eq(), EQ()),
-    #                 (rq(1.5), RQ(1.5)),
-    #                 (γ_exponential(2.0), GammaExp(2.0)),
-    #                 (poly(2, 0.6), Poly(2, 0.6)),
-    #             ]
-    #             stretched = [
-    #                 (eq(0.7), stretch(EQ(), 0.7)),
-    #                 (rq(1.5, 0.5), stretch(RQ(1.5), 0.5)),
-    #                 (γ_exponential(2.0, 0.53), stretch(GammaExp(2.0), 0.53)),
-    #                 (poly(2, 0.6, 0.4), stretch(Poly(2, 0.6), 0.4)),
-    #             ]
-    #             @testset "$k_conv" for (k_conv, k) in unstretched
-    #                 @test pw(k_conv, x0) ≈ pw(k, x0)
-    #                 differentiable_kernel_tests(k_conv, ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #             end
-    #             @testset "$k_conv" for (k_conv, k) in stretched
-    #                 @test pw(k_conv, x0) ≈ pw(k, x0)
-    #                 differentiable_kernel_tests(k_conv, ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #             end
+        @timedtestset "Stretched" begin
+            @timedtestset "Scalar a" begin
+                k = stretch(EQ(), 0.1)
+                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-7, rtol=1e-7)
+                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
+            end
+            @timedtestset "Vector a" begin
+                k = stretch(EQ(), randn(rng, D))
+                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
+            end
+            @timedtestset "Matrix a" begin
+                k = stretch(EQ(), randn(rng, D, D))
+                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
+            end
+            @timedtestset "Convenience Constructors" begin
+                unstretched = [
+                    (eq(), EQ()),
+                    (rq(1.5), RQ(1.5)),
+                    (γ_exponential(2.0), GammaExp(2.0)),
+                    (poly(2, 0.6), Poly(2, 0.6)),
+                ]
+                stretched = [
+                    (eq(0.7), stretch(EQ(), 0.7)),
+                    (rq(1.5, 0.5), stretch(RQ(1.5), 0.5)),
+                    (γ_exponential(2.0, 0.53), stretch(GammaExp(2.0), 0.53)),
+                    (poly(2, 0.6, 0.4), stretch(Poly(2, 0.6), 0.4)),
+                ]
+                @testset "$k_conv" for (k_conv, k) in unstretched
+                    @test pw(k_conv, x0) ≈ pw(k, x0)
+                    differentiable_kernel_tests(k_conv, ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                end
+                @testset "$k_conv" for (k_conv, k) in stretched
+                    @test pw(k_conv, x0) ≈ pw(k, x0)
+                    differentiable_kernel_tests(k_conv, ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                end
 
-    #             # Wiener kernels aren't differentiable.
-    #             not_diff_unstretched = [
-    #                 (wiener(), Wiener()),
-    #                 (wiener_velocity(), WienerVelocity()),
-    #             ]
-    #             not_diff_stretched = [
-    #                 (wiener(0.67), stretch(Wiener(), 0.67)),
-    #                 (wiener_velocity(0.65), stretch(WienerVelocity(), 0.65)),
-    #             ]
-    #             @testset "$k_conv" for (k_conv, k) in not_diff_unstretched
-    #                 @test pw(k_conv, x0) ≈ pw(k, x0)
-    #                 kernel_tests(k_conv, abs.(x0), abs.(x1), abs.(x2))
-    #             end
-    #             @testset "$k_conv" for (k_conv, k) in not_diff_stretched
-    #                 @test pw(k_conv, x0) ≈ pw(k, x0)
-    #                 kernel_tests(k_conv, abs.(x0), abs.(x1), abs.(x2))
-    #             end
-    #         end
-    #     end
+                # Wiener kernels aren't differentiable.
+                not_diff_unstretched = [
+                    (wiener(), Wiener()),
+                    (wiener_velocity(), WienerVelocity()),
+                ]
+                not_diff_stretched = [
+                    (wiener(0.67), stretch(Wiener(), 0.67)),
+                    (wiener_velocity(0.65), stretch(WienerVelocity(), 0.65)),
+                ]
+                @testset "$k_conv" for (k_conv, k) in not_diff_unstretched
+                    @test pw(k_conv, x0) ≈ pw(k, x0)
+                    kernel_tests(k_conv, abs.(x0), abs.(x1), abs.(x2))
+                end
+                @testset "$k_conv" for (k_conv, k) in not_diff_stretched
+                    @test pw(k_conv, x0) ≈ pw(k, x0)
+                    kernel_tests(k_conv, abs.(x0), abs.(x1), abs.(x2))
+                end
+            end
+        end
     end
 
     @timedtestset "(is)zero" begin

--- a/test/kernels.jl
+++ b/test/kernels.jl
@@ -5,8 +5,8 @@ https://www.github..com/willtebbutt/Stheno.jl
 
 using GPnet
 using GPnet: ZeroKernel, OneKernel, ConstKernel, pw#, Stretched, Scaled
-using GPnet: EQ, PerEQ, Exp, Matern32, Matern52, RQ, Cosine, Linear, Poly#, Noise, Cosine, Sum, Product, stretch,
-    #Poly, GammaExp, Wiener, WienerVelocity, Precomputed
+using GPnet: EQ, PerEQ, Exp, Matern32, Matern52, RQ, Cosine, Linear, Poly, GammaExp, Wiener, WienerVelocity, Noise#, Sum, Product, stretch,
+    #Poly, Precomputed
 using LinearAlgebra
 using TimerOutputs, Test, Random
 const to = TimerOutput()
@@ -130,34 +130,34 @@ include("test_util.jl")
             end
         end
 
-    #     @timedtestset "GammaExp" begin
-    #         @test pw(GammaExp(2.0), x0) ≈ pw(stretch(EQ(), sqrt(2)), x0)
-    #         @testset "γ=$γ" for γ in [1.0, 1.5, 2.0]
-    #             differentiable_kernel_tests(GammaExp(γ), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
-    #             differentiable_kernel_tests(GammaExp(γ), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
-    #         end
-    #     end
+        @timedtestset "GammaExp" begin
+            @test_broken pw(GammaExp(2.0), x0) ≈ pw(stretch(EQ(), sqrt(2)), x0)
+            @testset "γ=$γ" for γ in [1.0, 1.5, 2.0]
+                differentiable_kernel_tests(GammaExp(γ), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                differentiable_kernel_tests(GammaExp(γ), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+            end
+        end
 
-    #     @timedtestset "Wiener" begin
-    #         x0 = collect(range(0.1, 2.0; length=N)) .+ 1e-3 .* randn(rng, N)
-    #         x1 = collect(range(0.1, 2.3; length=N)) .+ 1e-3 .* randn(rng, N)
-    #         x2 = collect(range(0.1, 3.3; length=N′)) .+ 1e-3 .* randn(rng, N′)
-    #         kernel_tests(Wiener(), x0, x1, x2)
-    #     end
+        @timedtestset "Wiener" begin
+            x0 = collect(range(0.1, 2.0; length=N)) .+ 1e-3 .* randn(rng, N)
+            x1 = collect(range(0.1, 2.3; length=N)) .+ 1e-3 .* randn(rng, N)
+            x2 = collect(range(0.1, 3.3; length=N′)) .+ 1e-3 .* randn(rng, N′)
+            kernel_tests(Wiener(), x0, x1, x2)
+        end
 
-    #     @timedtestset "WienerVelocity" begin
-    #         x0 = collect(range(0.1, 2.0; length=N)) .+ 1e-3 .* randn(rng, N)
-    #         x1 = collect(range(0.1, 2.3; length=N)) .+ 1e-3 .* randn(rng, N)
-    #         x2 = collect(range(0.1, 3.3; length=N′)) .+ 1e-3 .* randn(rng, N′)
-    #         kernel_tests(WienerVelocity(), x0, x1, x2)
-    #     end
+        @timedtestset "WienerVelocity" begin
+            x0 = collect(range(0.1, 2.0; length=N)) .+ 1e-3 .* randn(rng, N)
+            x1 = collect(range(0.1, 2.3; length=N)) .+ 1e-3 .* randn(rng, N)
+            x2 = collect(range(0.1, 3.3; length=N′)) .+ 1e-3 .* randn(rng, N′)
+            kernel_tests(WienerVelocity(), x0, x1, x2)
+        end
 
-    #     @timedtestset "Noise" begin
-    #         @test ew(Noise(), x0, x0) == zeros(length(x0))
-    #         @test pw(Noise(), x0, x0) == zeros(length(x0), length(x0))
-    #         @test ew(Noise(), x0) == ones(length(x0))
-    #         @test pw(Noise(), x0) == Diagonal(ones(length(x0)))
-    #     end
+        @timedtestset "Noise" begin
+            @test ew(Noise(), x0, x0) == zeros(length(x0))
+            @test pw(Noise(), x0, x0) == zeros(length(x0), length(x0))
+            @test ew(Noise(), x0) == ones(length(x0))
+            @test pw(Noise(), x0) == Diagonal(ones(length(x0)))
+        end
 
     #     @timedtestset "precomputed" begin
     #         rng = MersenneTwister(123456)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,4 +2,5 @@ using GPnet, Test, Random
 
 Random.seed!(123456)
 
+include("kernels.jl")
 include("gpflow/gpflow.jl")

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -1,0 +1,379 @@
+using BlockArrays, LinearAlgebra, FiniteDifferences, Zygote, Random
+using GPJ: Kernel, AV, pairwise, ew, pw, BlockData, blocks
+#using GPJ: AbstractGP
+using LinearAlgebra: AbstractTriangular
+using FiniteDifferences: j′vp
+import FiniteDifferences: to_vec
+
+const _rtol = 1e-10
+const _atol = 1e-10
+
+_to_psd(A::Matrix{<:Real}) = A * A' + I
+_to_psd(a::Vector{<:Real}) = exp.(a) .+ 1
+_to_psd(σ::Real) = exp(σ) + 1
+#_to_psd(As::Vector{<:Matrix{<:Real}}) = block_diagonal(_to_psd.(As))
+
+Base.length(::Nothing) = 0
+
+function print_adjoints(adjoint_ad, adjoint_fd, rtol, atol)
+    @show typeof(adjoint_ad), typeof(adjoint_fd)
+    adjoint_ad, adjoint_fd = to_vec(adjoint_ad)[1], to_vec(adjoint_fd)[1]
+    println("atol is $atol, rtol is $rtol")
+    println("ad, fd, abs, rel")
+    abs_err = abs.(adjoint_ad .- adjoint_fd)
+    rel_err = abs_err ./ adjoint_ad
+    display([adjoint_ad adjoint_fd abs_err rel_err])
+    println()
+end
+
+# AbstractArrays.
+function to_vec(x::ColVecs{<:Real})
+    x_vec, back = to_vec(x.X)
+    return x_vec, x_vec -> ColVecs(back(x_vec))
+end
+to_vec(x::BlockArray) = vec(Array(x)), x_->BlockArray(reshape(x_, size(x)), blocksizes(x))
+function to_vec(x::BlockData)
+    x_vecs, x_backs = zip(map(to_vec, blocks(x))...)
+    sz = cumsum([map(length, x_vecs)...])
+    return vcat(x_vecs...), function(v)
+        return BlockData([x_backs[n](v[sz[n]-length(blocks(x)[n])+1:sz[n]])
+            for n in 1:length(blocks(x))])
+    end
+end
+function to_vec(X::T) where T<:Union{Adjoint,Transpose}
+    U = T.name.wrapper
+    return vec(Matrix(X)), x_vec->U(permutedims(reshape(x_vec, size(X))))
+end
+
+Base.zero(d::Dict) = Dict([(key, zero(val)) for (key, val) in d])
+Base.zero(x::Array) = zero.(x)
+
+# My version of isapprox
+function fd_isapprox(x_ad::Nothing, x_fd, rtol, atol)
+    return fd_isapprox(x_fd, zero(x_fd), rtol, atol)
+end
+function fd_isapprox(x_ad::AbstractArray, x_fd::AbstractArray, rtol, atol)
+    return all(fd_isapprox.(x_ad, x_fd, rtol, atol))
+end
+function fd_isapprox(x_ad::Real, x_fd::Real, rtol, atol)
+    return isapprox(x_ad, x_fd; rtol=rtol, atol=atol)
+end
+function fd_isapprox(x_ad::NamedTuple, x_fd, rtol, atol)
+    f = (x_ad, x_fd)->fd_isapprox(x_ad, x_fd, rtol, atol)
+    return all([f(getfield(x_ad, key), getfield(x_fd, key)) for key in keys(x_ad)])
+end
+function fd_isapprox(x_ad::Tuple, x_fd::Tuple, rtol, atol)
+    return all(map((x, x′)->fd_isapprox(x, x′, rtol, atol), x_ad, x_fd))
+end
+function fd_isapprox(x_ad::Dict, x_fd::Dict, rtol, atol)
+    return all([fd_isapprox(get(()->nothing, x_ad, key), x_fd[key], rtol, atol) for
+        key in keys(x_fd)])
+end
+
+function adjoint_test(
+    f, ȳ, x...;
+    rtol=_rtol,
+    atol=_atol,
+    fdm=FiniteDifferences.Central(5, 1),
+    print_results=false,
+)
+    # Compute forwards-pass and j′vp.
+    y, back = Zygote.pullback(f, x...)
+    @timeit to "adj_ad" adj_ad = back(ȳ)
+    @timeit to "adj_fd" adj_fd = j′vp(fdm, f, ȳ, x...)
+
+    # Check that forwards-pass agrees with plain forwards-pass.
+    @test y ≈ f(x...)
+
+    # Check that ad and fd adjoints (approximately) agree.
+    print_results && print_adjoints(adj_ad, adj_fd, rtol, atol)
+    @test fd_isapprox(adj_ad, adj_fd, rtol, atol)
+end
+
+# """
+#     mean_function_tests(m::MeanFunction, X::AbstractVector)
+
+# Test _very_ basic consistency properties of the mean function `m`.
+# """
+# function mean_function_tests(m::MeanFunction, x::AbstractVector)
+#     @test ew(m, x) isa AbstractVector
+#     @test length(ew(m, x)) == length(x)
+# end
+
+"""
+    cross_kernel_tests(k::Kernel, x0::AV, x1::AV, x2::AV)
+
+Tests that any cross kernel `k` should be able to pass. Requires that
+`length(x0) == length(x1)` and `length(x0) ≠ length(x2)`.
+"""
+function cross_kernel_tests(k::Kernel, x0::AV, x1::AV, x2::AV; atol=1e-9)
+    @assert length(x0) == length(x1)
+    @assert length(x0) ≠ length(x2)
+
+    # Check that elementwise basically works.
+    @test ew(k, x0, x1) isa AbstractVector
+    @test length(ew(k, x0, x1)) == length(x0)
+
+    # Check that pairwise basically works.
+    @test pw(k, x0, x2) isa AbstractMatrix
+    @test size(pw(k, x0, x2)) == (length(x0), length(x2))
+
+    # Check that elementwise is consistent with pairwise.
+    @test ew(k, x0, x1) ≈ diag(pw(k, x0, x1)) atol=atol
+end
+
+"""
+    kernel_tests(k::Kernel, X0::AbstractVector, X1::AbstractVector, X2::AbstractVector)
+
+Tests that any kernel `k` should be able to pass. Requires that `length(X0) == length(X1)`
+and `length(X0) ≠ length(X2)`.
+"""
+function kernel_tests(k::Kernel, x0::AV, x1::AV, x2::AV; atol=1e-9)
+    @assert length(x0) == length(x1)
+    @assert length(x0) ≠ length(x2)
+
+    # Check that all of the binary methods work as expected.
+    cross_kernel_tests(k, x0, x1, x2)
+
+    # Check additional binary elementwise properties for kernels.
+    @test ew(k, x0, x1) ≈ ew(k, x1, x0)
+    @test pw(k, x0, x2) ≈ pw(k, x2, x0)' atol=atol
+
+    # Check that unary elementwise basically works.
+    @test ew(k, x0) isa AbstractVector
+    @test length(ew(k, x0)) == length(x0)
+
+    # Check that unary pairwise basically works.
+    @test pw(k, x0) isa AbstractMatrix
+    @test size(pw(k, x0)) == (length(x0), length(x0))
+    @test pw(k, x0) ≈ pw(k, x0)' atol=atol
+
+    # Check that unary elementwise is consistent with unary pairwise.
+    @test ew(k, x0) ≈ diag(pw(k, x0)) atol=atol
+
+    # Check that unary pairwise produces a positive definite matrix (approximately).
+    @test all(eigvals(Matrix(pw(k, x0))) .> -atol)
+
+    # Check that unary elementwise / pairwise are consistent with the binary versions.
+    @test ew(k, x0) ≈ ew(k, x0, x0) atol=atol
+    @test pw(k, x0) ≈ pw(k, x0, x0) atol=atol
+end
+
+# """
+#     differentiable_mean_function_tests(m::MeanFunction, ȳ::AV, x::AV)
+
+# Ensure that the gradient w.r.t. the inputs of `MeanFunction` `m` are approximately correct.
+# """
+# function differentiable_mean_function_tests(
+#     m::MeanFunction,
+#     ȳ::AbstractVector{<:Real},
+#     x::AbstractVector{<:Real};
+#     rtol=_rtol,
+#     atol=_atol,
+# )
+#     # Run forward tests.
+#     mean_function_tests(m, x)
+
+#     # Check adjoint.
+#     @assert length(ȳ) == length(x)
+#     adjoint_test(x->ew(m, x), ȳ, x; rtol=rtol, atol=atol)
+# end
+# function differentiable_mean_function_tests(
+#     m::MeanFunction,
+#     ȳ::AbstractVector{<:Real},
+#     x::ColVecs{<:Real};
+#     rtol=_rtol,
+#     atol=_atol,
+# )
+#     # Run forward tests.
+#     mean_function_tests(m, x)
+
+#     @assert length(ȳ) == length(x)
+#     adjoint_test(X->ew(m, ColVecs(X)), ȳ, x.X; rtol=rtol, atol=atol)  
+# end
+# function differentiable_mean_function_tests(
+#     rng::AbstractRNG,
+#     m::MeanFunction,
+#     x::AV;
+#     rtol=_rtol,
+#     atol=_atol,
+# )
+#     return differentiable_mean_function_tests(
+#         m,
+#         randn(rng, length(x)),
+#         x;
+#         rtol=rtol,
+#         atol=atol,
+#     )
+# end
+
+"""
+    differentiable_cross_kernel_tests(
+        k::Kernel,
+        ȳ::AbstractVector{<:Real},
+        Ȳ::AbstractMatrix{<:Real},
+        x0::AbstractVector,
+        x1::AbstractVector,
+        x2::AbstractVector,
+    )
+
+Ensure that the adjoint w.r.t. the inputs of a `Kernel` which is supposed to be
+differentiable are approximately correct.
+"""
+function differentiable_cross_kernel_tests(
+    k::Kernel,
+    ȳ::AbstractVector{<:Real},
+    Ȳ::AbstractMatrix{<:Real},
+    x0::AbstractVector,
+    x1::AbstractVector,
+    x2::AbstractVector;
+    rtol=_rtol,
+    atol=_atol,
+)
+    # Run forwards-pass cross kernel tests.
+    cross_kernel_tests(k, x0, x1, x2)
+
+    # Ensure that the inputs are as required.
+    @assert length(ȳ) == length(x0)
+    @assert length(ȳ) == length(x1)
+    @assert size(Ȳ) == (length(x0), length(x2))
+
+    # Binary elementwise.
+    adjoint_test((x, x′)->ew(k, x, x′), ȳ, x0, x1; rtol=rtol, atol=atol)
+
+    # Binary pairwise.
+    adjoint_test((x, x′)->pw(k, x, x′), Ȳ, x0, x2; rtol=rtol, atol=atol)
+end
+function differentiable_cross_kernel_tests(
+    rng::AbstractRNG,
+    k::Kernel,
+    x0::AV,
+    x1::AV,
+    x2::AV;
+    rtol=_rtol,
+    atol=_atol,
+)
+    ȳ, Ȳ = randn(rng, length(x0)), randn(rng, length(x0), length(x2))
+    return differentiable_cross_kernel_tests(k, ȳ, Ȳ, x0, x1, x2; rtol=rtol, atol=atol)
+end
+
+"""
+    differentiable_kernel_tests(
+        k::Kernel,
+        ȳ::AbstractVector{<:Real},
+        Ȳ::AbstractMatrix{<:Real},
+        Ȳ_sq::AbstractMatrix{<:Real},
+        x0::AbstractVector,
+        x1::AbstractVector,
+        x2::AbstractVector,
+    )
+
+A superset of the tests provided by `differentiable_cross_kernel_tests` designed to test
+kernels (which provide unary, in addition to binary, methods for `elementwise` and
+`pairwise`.)
+"""
+function differentiable_kernel_tests(
+    k::Kernel,
+    ȳ::AbstractVector{<:Real},
+    Ȳ::AbstractMatrix{<:Real},
+    Ȳ_sq::AbstractMatrix{<:Real},
+    x0::AbstractVector,
+    x1::AbstractVector,
+    x2::AbstractVector;
+    rtol=_rtol,
+    atol=_atol,
+)
+    # Run the forwards-pass kernel tests.
+    kernel_tests(k, x0, x1, x2)
+
+    # Ensure that the inputs are as required.
+    @assert length(ȳ) == length(x0)
+    @assert length(ȳ) == length(x1)
+    @assert size(Ȳ) == (length(x0), length(x2))
+    @assert size(Ȳ_sq, 1) == size(Ȳ_sq, 2)
+    @assert size(Ȳ_sq, 1) == length(x0)
+
+    # Run the Kernel tests.
+    differentiable_cross_kernel_tests(k, ȳ, Ȳ, x0, x1, x2; rtol=rtol, atol=atol)
+
+    # Unary elementwise tests.
+    adjoint_test(x->ew(k, x), ȳ, x0; rtol=rtol, atol=atol)
+
+    # Unary pairwise test.
+    adjoint_test(x->pw(k, x), Ȳ_sq, x0; rtol=rtol, atol=atol)
+end
+function differentiable_kernel_tests(
+    rng::AbstractRNG,
+    k::Kernel,
+    x0::AV,
+    x1::AV,
+    x2::AV;
+    rtol=_rtol,
+    atol=_atol,
+)
+    N, N′ = length(x0), length(x2)
+    ȳ, Ȳ, Ȳ_sq = randn(rng, N), randn(rng, N, N′), randn(rng, N, N)
+    return differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, x0, x1, x2; rtol=rtol, atol=atol)
+end
+
+# """
+#     abstractgp_interface_tests(
+#         f::AbstractGP, f′::AbstractGP, x0::AV, x1::AV, x2::AV, x3::AV;
+#         atol=1e-9, rtol=1e-9,
+#     )
+
+# Check that the `AbstractGP` interface is at least implemented for `f` and is
+# self-consistent. `x0` and `x1` must be valid inputs for `f`. `x2` and `x3` must be a valid
+# input for `f′`.
+# """
+# function abstractgp_interface_tests(
+#     f::AbstractGP, f′::AbstractGP, x0::AV, x1::AV, x2::AV, x3::AV;
+#     atol=1e-9, rtol=1e-9,
+# )
+#     m = mean_vector(f, x0)
+#     @test m isa AbstractVector{<:Real}
+#     @test length(m) == length(x0)
+
+#     @assert length(x0) ≠ length(x1)
+#     @assert length(x0) ≠ length(x2)
+#     @assert length(x0) == length(x3)
+
+#     # Check that binary cov conforms to the API
+#     K_ff′_x0_x2 = cov(f, f′, x0, x2)
+#     @test K_ff′_x0_x2 isa AbstractMatrix{<:Real}
+#     @test size(K_ff′_x0_x2) == (length(x0), length(x2))
+#     @test K_ff′_x0_x2 ≈ cov(f′, f, x2, x0)'
+
+#     # Check that unary cov is consistent with binary cov and conforms to the API
+#     K_x0 = cov(f, x0)
+#     @test K_x0 isa AbstractMatrix{<:Real}
+#     @test size(K_x0) == (length(x0), length(x0))
+#     @test K_x0 ≈ cov(f, f, x0, x0) atol=atol rtol=rtol
+#     @test minimum(eigvals(K_x0)) > -atol
+#     @test K_x0 ≈ K_x0' atol=atol rtol=rtol
+
+#     # Check that single-process binary cov is consistent with binary-process binary-cov
+#     K_x0_x1 = cov(f, x0, x1)
+#     @test K_x0_x1 isa AbstractMatrix{<:Real}
+#     @test size(K_x0_x1) == (length(x0), length(x1))
+#     @test K_x0_x1 ≈ cov(f, f, x0, x1)
+
+#     # Check that binary cov_diag conforms to the API and is consistent with binary cov
+#     K_x0_x3_diag = cov_diag(f, f′, x0, x3)
+#     @test K_x0_x3_diag isa AbstractVector{<:Real}
+#     @test length(K_x0_x3_diag) == length(x0)
+#     @test K_x0_x3_diag ≈ diag(cov(f, f′, x0, x3)) atol=atol rtol=rtol
+#     @test K_x0_x3_diag ≈ cov_diag(f′, f, x3, x0) atol=atol rtol=rtol
+
+#     # Check that unary-binary cov_diag is consistent.
+#     K_x0_x0_diag = cov_diag(f, x0, x0)
+#     @test K_x0_x0_diag isa AbstractVector{<:Real}
+#     @test length(K_x0_x0_diag) == length(x0)
+#     @test K_x0_x0_diag ≈ diag(cov(f, x0, x0)) atol=atol rtol=rtol
+
+#     # Check that unary cov_diag conforms to the API and is consistent with unary cov
+#     K_x0_diag = cov_diag(f, x0)
+#     @test K_x0_diag isa AbstractVector{<:Real}
+#     @test length(K_x0_diag) == length(x0)
+#     @test K_x0_diag ≈ diag(cov(f, x0)) atol=atol rtol=rtol
+# end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -1,6 +1,6 @@
 using BlockArrays, LinearAlgebra, FiniteDifferences, Zygote, Random
-using GPJ: Kernel, AV, pairwise, ew, pw, BlockData, blocks
-#using GPJ: AbstractGP
+using GPnet: Kernel, AV, pairwise, ew, pw, BlockData, blocks
+#using GPnet: AbstractGP
 using LinearAlgebra: AbstractTriangular
 using FiniteDifferences: j′vp
 import FiniteDifferences: to_vec


### PR DESCRIPTION
This effort to is to collect a standalone library of kernels for easy future use and maintenance.

Much of the code would be borrowed from existing open-source Julia projects:

- [Stheno.jl](https://github.com/willtebbutt/Stheno.jl) ([License](https://github.com/willtebbutt/Stheno.jl/blob/master/LICENSE.md))
- [GaussianProcesses.jl](https://github.com/STOR-i/GaussianProcesses.jl) ([License](https://github.com/STOR-i/GaussianProcesses.jl/blob/master/LICENSE.md))
- [GPKit.jl](https://github.com/adriancu/GPkit.jl) ([License](https://github.com/adriancu/GPkit.jl/blob/master/COPYRIGHT-GPML_Toolbox))

The main aim for this work is to - 
- Refactor existing Julia code to standardize the API for all these collected kernel.
- Keep the code as user readable as possible for easy addition/maintenance of new kernels.
- Have minimal dependencies,
- Add any and all missing kernels from GPML. 

Existing API examples:
**Stheno.jl**
```julia

    # Binary methods
    ew(k::MyKernel, x::AbstractVector, x′::AbstractVector) # "Binary elementwise"
    pw(k::MyKernel, x::AbstractVector, x′::AbstractVector) # "Binary pairwise"
    
    # Unary methods
    ew(k::MyKernel, x::AbstractVector) # "Unary elementwise"
    pw(k::MyKernel, x::AbstractVector) # "Unary pairwise"
```
**GaussianProcesses.jl**
```julia
    cov(k::Kernel, X1::AbstractMatrix, X2::AbstractMatrix)
```
Some variation of these API needs to be adopted which can best accommodate current and future kernels.